### PR TITLE
Change from wlr to hyprland so dbus would recognize

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -111,7 +111,7 @@ static char *config_path(const char *prefix, const char *filename) {
 		return NULL;
 	}
 
-	char *config_folder = "xdg-desktop-portal-wlr";
+	char *config_folder = "xdg-desktop-portal-hyprland";
 
 	size_t size = 3 + strlen(prefix) + strlen(config_folder) + strlen(filename);
 	char *path = calloc(size, sizeof(char));

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -18,16 +18,16 @@ enum event_loop_fd {
 	EVENT_LOOP_TIMER,
 };
 
-static const char service_name[] = "org.freedesktop.impl.portal.desktop.wlr";
+static const char service_name[] = "org.freedesktop.impl.portal.desktop.hyprland";
 
 static int xdpw_usage(FILE *stream, int rc) {
 	static const char *usage =
-		"Usage: xdg-desktop-portal-wlr [options]\n"
+		"Usage: xdg-desktop-portal-hyprland [options]\n"
 		"\n"
 		"    -l, --loglevel=<loglevel>        Select log level (default is ERROR).\n"
 		"                                     QUIET, ERROR, WARN, INFO, DEBUG, TRACE\n"
 		"    -c, --config=<config file>	      Select config file.\n"
-		"                                     (default is $XDG_CONFIG_HOME/xdg-desktop-portal-wlr/config)\n"
+		"                                     (default is $XDG_CONFIG_HOME/xdg-desktop-portal-hyprland/config)\n"
 		"    -r, --replace                    Replace a running instance.\n"
 		"    -h, --help                       Get help (this text).\n"
 		"\n";

--- a/src/screencast/screencast_common.c
+++ b/src/screencast/screencast_common.c
@@ -275,7 +275,7 @@ enum wl_shm_format xdpw_format_wl_shm_from_drm_fourcc(uint32_t format) {
 	case DRM_FORMAT_BGRA1010102:
 		return (enum wl_shm_format)format;
 	default:
-		logprint(ERROR, "xdg-desktop-portal-wlr: unsupported drm "
+		logprint(ERROR, "xdg-desktop-portal-hyprland: unsupported drm "
 			"format 0x%08x", format);
 		abort();
 	}
@@ -304,7 +304,7 @@ uint32_t xdpw_format_drm_fourcc_from_wl_shm(enum wl_shm_format format) {
 	case WL_SHM_FORMAT_BGRA1010102:
 		return (uint32_t)format;
 	default:
-		logprint(ERROR, "xdg-desktop-portal-wlr: unsupported wl_shm "
+		logprint(ERROR, "xdg-desktop-portal-hyprland: unsupported wl_shm "
 			"format 0x%08x", format);
 		abort();
 	}
@@ -347,7 +347,7 @@ enum spa_video_format xdpw_format_pw_from_drm_fourcc(uint32_t format) {
 	case DRM_FORMAT_BGRA1010102:
 		return SPA_VIDEO_FORMAT_BGRA_102LE;
 	default:
-		logprint(ERROR, "xdg-desktop-portal-wlr: failed to convert drm "
+		logprint(ERROR, "xdg-desktop-portal-hyprland: failed to convert drm "
 			"format 0x%08x to spa_video_format", format);
 		abort();
 	}


### PR DESCRIPTION
`service_name` in `main.c` file needs to be changed so dbus would recognize the service in xdg-desktop-portal.  Otherwise it stucks on `activating` (and timeouts eventually) because a service with such a name does not appear.