### PR TITLE
nix: adds grim and slurp to PATH to support screenshots

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,6 +9,8 @@
   wayland-protocols,
   wayland-scanner,
   hyprland-share-picker,
+  grim,
+  slurp,
   hyprland-protocols,
   inih,
   libdrm,
@@ -35,7 +37,7 @@ stdenv.mkDerivation {
   ];
 
   postInstall = ''
-    wrapProgram $out/libexec/xdg-desktop-portal-hyprland --prefix PATH ":" ${lib.makeBinPath [hyprland-share-picker]}
+    wrapProgram $out/libexec/xdg-desktop-portal-hyprland --prefix PATH ":" ${lib.makeBinPath [hyprland-share-picker grim slurp]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
The portal needs `grim` and `slurp` in `PATH` to enable support for screenshots.
This PR adds these for the nix package