### PR TITLE
systemd: switch slice for xdph

### DIFF
--- a/contrib/systemd/xdg-desktop-portal-hyprland.service.in
+++ b/contrib/systemd/xdg-desktop-portal-hyprland.service.in
@@ -9,3 +9,4 @@ Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.hyprland
 ExecStart=@libexecdir@/xdg-desktop-portal-hyprland
 Restart=on-failure
+Slice=session.slice


### PR DESCRIPTION
Consider xdg-desktop-portal-hyprland as essential for user's graphic session

See https://systemd.io/DESKTOP_ENVIRONMENTS/