### PR TITLE
fix implicit function declaration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ add_project_arguments(cc.get_supported_arguments([
 	'-Wno-missing-field-initializers',
 	'-Wno-unused-parameter',
 	'-D_POSIX_C_SOURCE=200809L',
+	'-D_GNU_SOURCE',
 ]), language: 'c')
 
 prefix = get_option('prefix')

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "utils.h"
 
 char *getFormat(const char *fmt, ...) {


### PR DESCRIPTION
Implicitly declared functions result only in a warning on GCC<=13 and clang<=16. However, starting with clang16 and probably also GCC14 once it is released -Wimplicit-function-declaration will be the default setting and the call of vasprintf will result in an error. 