### PR TITLE
screencast: correct array size

### DIFF
--- a/src/screencast/pipewire_screencast.c
+++ b/src/screencast/pipewire_screencast.c
@@ -203,7 +203,7 @@ static void pwr_handle_stream_param_changed(void *data, uint32_t id,
 	struct pw_stream *stream = cast->stream;
 	uint8_t params_buffer[3][1024];
 	struct spa_pod_dynamic_builder b[3];
-	const struct spa_pod *params[3];
+	const struct spa_pod *params[4];
 	uint32_t blocks;
 	uint32_t data_type;
 


### PR DESCRIPTION
Fixes my issue #71 
It seems like on line [325](https://github.com/nik012003/xdg-desktop-portal-hyprland/blob/4001b8a081c59ce84386cd9a8485c03e89affe87/src/screencast/pipewire_screencast.c#L325) there was an assigment to `params[3]` which is out of bounds. This undefined behaviour causes problems on aarch64. 
WARNING: I only tested this on aarch64, since I don't have an x86 box laying around, but it shouldnt cause any issues. 
Btw there are a few other problems on aarch64 due to rouge pointer comparaisons, which I will try to address in the next PR.