### PR TITLE
Nix: Some corrections for overlays

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,7 +39,23 @@
     "root": {
       "inputs": {
         "hyprland-protocols": "hyprland-protocols",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,6 @@
       (self.overlays.default pkgsFor.${system} pkgsFor.${system})
       // {default = self.packages.${system}.xdg-desktop-portal-hyprland;});
 
-    formatter = genSystems (system: pkgsFor.${system}.alejandra);
+    formatter = genSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -28,21 +28,8 @@
           inputs.hyprland-protocols.overlays.default
         ];
       });
-    mkDate = longDate: (lib.concatStringsSep "-" [
-      (builtins.substring 0 4 longDate)
-      (builtins.substring 4 2 longDate)
-      (builtins.substring 6 2 longDate)
-    ]);
-    version = "0.pre" + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
   in {
-    overlays.default = final: prev: {
-      xdg-desktop-portal-hyprland = final.callPackage ./nix/default.nix {
-        inherit (final) hyprland-protocols hyprland-share-picker;
-        inherit version;
-      };
-
-      hyprland-share-picker = final.libsForQt5.callPackage ./nix/hyprland-share-picker.nix {inherit version;};
-    };
+    overlays = import ./nix/overlays.nix {inherit self inputs lib;};
 
     packages = genSystems (system:
       (self.overlays.default pkgsFor.${system} pkgsFor.${system})

--- a/flake.nix
+++ b/flake.nix
@@ -25,16 +25,18 @@
       import nixpkgs {
         localSystem = system;
         overlays = [
-          self.overlays.default
           inputs.hyprland-protocols.overlays.default
+          self.overlays.xdg-desktop-portal-hyprland
+          self.overlays.hyprland-share-picker
         ];
       });
   in {
     overlays = import ./nix/overlays.nix {inherit self inputs lib;};
 
-    packages = eachSystem (system:
-      (self.overlays.default pkgsFor.${system} pkgsFor.${system})
-      // {default = self.packages.${system}.xdg-desktop-portal-hyprland;});
+    packages = eachSystem (system: {
+      inherit (pkgsFor.${system}) xdg-desktop-portal-hyprland hyprland-share-picker;
+      default = self.packages.${system}.xdg-desktop-portal-hyprland;
+    });
 
     formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.alejandra);
   };

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,9 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    # <https://github.com/nix-systems/nix-systems>
+    systems.url = "github:nix-systems/default-linux";
+
     hyprland-protocols = {
       url = "github:hyprwm/hyprland-protocols";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -13,16 +16,14 @@
   outputs = {
     self,
     nixpkgs,
+    systems,
     ...
   } @ inputs: let
     inherit (nixpkgs) lib;
-    genSystems = lib.genAttrs [
-      "aarch64-linux"
-      "x86_64-linux"
-    ];
-    pkgsFor = genSystems (system:
+    eachSystem = lib.genAttrs (import systems);
+    pkgsFor = eachSystem (system:
       import nixpkgs {
-        inherit system;
+        localSystem = system;
         overlays = [
           self.overlays.default
           inputs.hyprland-protocols.overlays.default
@@ -31,10 +32,10 @@
   in {
     overlays = import ./nix/overlays.nix {inherit self inputs lib;};
 
-    packages = genSystems (system:
+    packages = eachSystem (system:
       (self.overlays.default pkgsFor.${system} pkgsFor.${system})
       // {default = self.packages.${system}.xdg-desktop-portal-hyprland;});
 
-    formatter = genSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
+    formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.alejandra);
   };
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,28 @@
+{
+  self,
+  inputs,
+  lib,
+}: let
+  mkJoinedOverlays = overlays: final: prev:
+    lib.foldl' (attrs: overlay: attrs // (overlay final prev)) {} overlays;
+  mkDate = longDate: (lib.concatStringsSep "-" [
+    (builtins.substring 0 4 longDate)
+    (builtins.substring 4 2 longDate)
+    (builtins.substring 6 2 longDate)
+  ]);
+  version = "0.pre" + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
+in {
+  default = mkJoinedOverlays (with self.overlays; [
+    xdg-desktop-portal-hyprland
+    hyprland-share-picker
+  ]);
+  xdg-desktop-portal-hyprland = final: prev: {
+    xdg-desktop-portal-hyprland = final.callPackage ./default.nix {
+      inherit (final) hyprland-protocols hyprland-share-picker;
+      inherit version;
+    };
+  };
+  hyprland-share-picker = final: prev: {
+    hyprland-share-picker = final.libsForQt5.callPackage ./hyprland-share-picker.nix {inherit version;};
+  };
+}


### PR DESCRIPTION
1. The `nix fmt` command did not work for me so I have reverted it to use `legacyPackages` for simplicity. It works now.
2. Before there was one `default` overlay, which would make it hard to get individual packages out from the overlay. Would need an extra wrapper function. Now each package has its own overlay, while `default` combines them all. Brought in `mkJoinedOverlays` from the Hyprland flake.
   - ```nix
     $ nix eval 'path:.#overlays' --apply 'builtins.attrNames'
     [ "default" "hyprland-share-picker" "xdg-desktop-portal-hyprland" ]
     ```
3. Moved `version` into `nix/overlays.nix`.
   - Perhaps we should adopt my (unpublished) changes from `Alexays/Waybar` and pull the first version fragment from `meson.build`.
5. Added another input `nix-systems` so that the `systems` is overrideable. I like this much better than using `flake-utils` or `flake-parts`.
   - Using `default-linux`, which is `[ "x86_64-linux" "aarch64-linux" ]`.
   - Updated usage when importing `nixpkgs` to correct for undocumented deprecation of `system`.
   - https://github.com/nix-systems/nix-systems
6. The attributes of the `packages` output are inherited from internal `pkgsFor`, which contains all of the overlays pre-applied.
   - ```nix
     $ nix eval 'path:.#packages.x86_64-linux' --apply 'builtins.attrNames'
     [ "default" "hyprland-share-picker" "xdg-desktop-portal-hyprland" ]
     ```