### PR TITLE
fix(xdg-desktop-portal-hyprland.service.in): loosen contraints

### DIFF
--- a/contrib/systemd/xdg-desktop-portal-hyprland.service.in
+++ b/contrib/systemd/xdg-desktop-portal-hyprland.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Portal service (Hyprland implementation)
 PartOf=graphical-session.target
-After=graphical-session.target
 ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]


### PR DESCRIPTION
I removed the After constraint because of the following reasons:

1. It serves no purpose: There is absolutely no reason why it should run after graphical-session.target as the only dependencies I was aware of seemed to be the hyprland activation and dbus.service. The former is already ensured by the conditional and the latter by the type.
2. It creates races with applications started by xdg-desktop-autostart.target that depend on functionality provided by the xdg-desktop-portal. Many services cannot activate without xdg-desktop-portal-hyprland.service but are not supposed to be edited because they are auto-generated or conform to freedesktop standards.
3. It can run way earlier: The necessary environment variables are initialised even before systemd start the dependencies of hyprlans-session.target. Even starting as early as basic.target already ensures that all dependencies are set. In any way systemd and dbus were made so we don't have to worry about this. not specifying anything causes the service to be started by dbus when needed.