### PR TITLE
feat: add double quote escaping

### DIFF
--- a/src/shared/ScreencopyShared.cpp
+++ b/src/shared/ScreencopyShared.cpp
@@ -21,16 +21,23 @@ std::string sanitizeNameForWindowList(const std::string& name) {
 }
 
 std::string buildWindowList() {
-    std::string result = "";
+    std::string result     = "";
+	std::string tmp_result = "";
     if (!g_pPortalManager->m_sPortals.screencopy->hasToplevelCapabilities())
         return result;
 
     for (auto& e : g_pPortalManager->m_sHelpers.toplevel->m_vToplevels) {
 
-        result += std::format("{}[HC>]{}[HT>]{}[HE>]", (uint32_t)(((uint64_t)e->handle) & 0xFFFFFFFF), sanitizeNameForWindowList(e->windowClass),
-                              sanitizeNameForWindowList(e->windowTitle));
+        tmp_result += std::format("{}[HC>]{}[HT>]{}[HE>]", (uint32_t)(((uint64_t)e->handle) & 0xFFFFFFFF), sanitizeNameForWindowList(e->windowClass),
+                                  sanitizeNameForWindowList(e->windowTitle));
     }
-
+	for (auto c: tmp_result) {
+		if (c == '\"') {
+			result += "\\\"";
+		} else {
+			result += c;
+		}
+	}
     return result;
 }
 

--- a/src/shared/ScreencopyShared.cpp
+++ b/src/shared/ScreencopyShared.cpp
@@ -11,7 +11,8 @@
 
 std::string sanitizeNameForWindowList(const std::string& name) {
     std::string result = name;
-	if (result[0] == '\"') result[0] = ' ';
+    if (result[0] == '\"')
+        result[0] = ' ';
     for (size_t i = 1; i < result.size(); ++i) {
         if (result[i - 1] == '>' && result[i] == ']')
             result[i] = ' ';
@@ -22,14 +23,14 @@ std::string sanitizeNameForWindowList(const std::string& name) {
 }
 
 std::string buildWindowList() {
-    std::string result     = "";
+    std::string result = "";
     if (!g_pPortalManager->m_sPortals.screencopy->hasToplevelCapabilities())
         return result;
 
     for (auto& e : g_pPortalManager->m_sHelpers.toplevel->m_vToplevels) {
 
         result += std::format("{}[HC>]{}[HT>]{}[HE>]", (uint32_t)(((uint64_t)e->handle) & 0xFFFFFFFF), sanitizeNameForWindowList(e->windowClass),
-                                  sanitizeNameForWindowList(e->windowTitle));
+                              sanitizeNameForWindowList(e->windowTitle));
     }
 
     return result;

--- a/src/shared/ScreencopyShared.cpp
+++ b/src/shared/ScreencopyShared.cpp
@@ -11,6 +11,7 @@
 
 std::string sanitizeNameForWindowList(const std::string& name) {
     std::string result = name;
+	if (result[0] == '\"') result[0] = ' ';
     for (size_t i = 1; i < result.size(); ++i) {
         if (result[i - 1] == '>' && result[i] == ']')
             result[i] = ' ';
@@ -22,22 +23,15 @@ std::string sanitizeNameForWindowList(const std::string& name) {
 
 std::string buildWindowList() {
     std::string result     = "";
-	std::string tmp_result = "";
     if (!g_pPortalManager->m_sPortals.screencopy->hasToplevelCapabilities())
         return result;
 
     for (auto& e : g_pPortalManager->m_sHelpers.toplevel->m_vToplevels) {
 
-        tmp_result += std::format("{}[HC>]{}[HT>]{}[HE>]", (uint32_t)(((uint64_t)e->handle) & 0xFFFFFFFF), sanitizeNameForWindowList(e->windowClass),
+        result += std::format("{}[HC>]{}[HT>]{}[HE>]", (uint32_t)(((uint64_t)e->handle) & 0xFFFFFFFF), sanitizeNameForWindowList(e->windowClass),
                                   sanitizeNameForWindowList(e->windowTitle));
     }
-	for (auto c: tmp_result) {
-		if (c == '\"') {
-			result += "\\\"";
-		} else {
-			result += c;
-		}
-	}
+
     return result;
 }
 


### PR DESCRIPTION
This pr will add an escape char for double quote in the window title string
- issue 
```txt
[LOG] [screencopy] SelectSources:
[LOG] [screencopy]  | /org/freedesktop/portal/desktop/request/1_56507/obs2
[LOG] [screencopy]  | /org/freedesktop/portal/desktop/session/1_56507/obs1
[LOG] [screencopy]  | appid:
[LOG] [screencopy] option cursor_mode to 2
[LOG] [screencopy] option persist_mode to 2
[LOG] [screencopy] unused option multiple
[LOG] [screencopy] unused option types
[LOG] [screencopy] restore data invalid / missing, prompting
[LOG] execAndGet: WAYLAND_DISPLAY=wayland-1 QT_QPA_PLATFORM="wayland" XCURSOR_SIZE=24 HYPRLAND_INSTANCE_SIGNATURE=d126d2c09204a09b0b10ce4f999520fc901fbf0a_1694861673 XDPH_WINDOW_SHARING_LIST="3451312672[HC>]Alacritty[HT>]./build/xdg-desktop-portal-hyprland[HE>]3451313024[HC>]discord[HT>]"testing pr  | NUCLEAR POWER PLANT - Discord[HE>]3451313424[HC>]Alacritty[HT>]goad@arch-btw:~/git/testing/xdg-desktop-portal-hyprland[HE>]3451313776[HC>]brave-browser[HT>]Comparing hyprwm:master...commrade-goad:quote-escape · hyprwm/xdg-desktop-portal-hyprland - Brave[HE>]" hyprland-share-picker 2>&1
sh: -c: line 1: unexpected EOF while looking for matching `"'
sh: -c: line 2: syntax error: unexpected end of file
[LOG] [screencopy] SHAREDATA returned selection -1
```
