### PR TITLE
Fix build when using clang

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,10 +25,11 @@ endif
 add_project_arguments(cpp_compiler.get_supported_arguments([
   '-Wno-missing-field-initializers',
   '-Wno-narrowing',
-	'-Wno-pointer-arith',
+  '-Wno-pointer-arith',
   '-Wno-unused-parameter',
   '-Wno-unused-value',
-	'-fpermissive'
+  '-fpermissive',
+  '-Wno-address-of-temporary'
 ]), language: 'cpp')
 
 conf_data = configuration_data()

--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -1,7 +1,6 @@
 #include "PortalManager.hpp"
 #include "../helpers/Log.hpp"
 
-#include <cstdint>
 #include <protocols/hyprland-global-shortcuts-v1-protocol.h>
 #include <protocols/hyprland-toplevel-export-v1-protocol.h>
 #include <protocols/wlr-foreign-toplevel-management-unstable-v1-protocol.h>

--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -1,6 +1,7 @@
 #include "PortalManager.hpp"
 #include "../helpers/Log.hpp"
 
+#include <cstdint>
 #include <protocols/hyprland-global-shortcuts-v1-protocol.h>
 #include <protocols/hyprland-toplevel-export-v1-protocol.h>
 #include <protocols/wlr-foreign-toplevel-management-unstable-v1-protocol.h>
@@ -169,7 +170,8 @@ static void dmabufFeedbackTrancheFormats(void* data, zwp_linux_dmabuf_feedback_v
     uint32_t  n_modifiers = g_pPortalManager->m_sWaylandConnection.dma.formatTableSize / sizeof(struct fm_entry);
     fm_entry* fm_entry    = (struct fm_entry*)g_pPortalManager->m_sWaylandConnection.dma.formatTable;
     uint16_t* idx;
-    wl_array_for_each(idx, indices) {
+
+    for (idx = reinterpret_cast<uint16_t*>(indices->data); reinterpret_cast<const char*>(idx) < reinterpret_cast<const char*>(indices->data) + indices->size; idx++) {
         if (*idx >= n_modifiers)
             continue;
 

--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -170,7 +170,7 @@ static void dmabufFeedbackTrancheFormats(void* data, zwp_linux_dmabuf_feedback_v
     fm_entry* fm_entry    = (struct fm_entry*)g_pPortalManager->m_sWaylandConnection.dma.formatTable;
     uint16_t* idx;
 
-    for (idx = reinterpret_cast<uint16_t*>(indices->data); reinterpret_cast<const char*>(idx) < reinterpret_cast<const char*>(indices->data) + indices->size; idx++) {
+    for (idx = (uint16_t*)indices->data; (const char*)idx < (const char*)indices->data + indices->size; idx++) {
         if (*idx >= n_modifiers)
             continue;
 

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -781,7 +781,7 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param) 
             const spa_pod* pod_modifier = &prop_modifier->value;
 
             uint32_t       n_modifiers = SPA_POD_CHOICE_N_VALUES(pod_modifier) - 1;
-            uint64_t*      modifiers   = SPA_POD_CHOICE_VALUES(pod_modifier);
+            uint64_t*      modifiers   = reinterpret_cast<uint64_t*>(SPA_POD_CHOICE_VALUES(pod_modifier));
             modifiers++;
             uint32_t         flags = GBM_BO_USE_RENDERING;
             uint64_t         modifier;
@@ -853,14 +853,16 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param) 
 
     params[0] = build_buffer(&dynBuilder[0].b, blocks, PSTREAM->pSession->sharingData.frameInfoSHM.size, PSTREAM->pSession->sharingData.frameInfoSHM.stride, data_type);
 
-    params[1] = spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_Header), SPA_PARAM_META_size,
-                                           SPA_POD_Int(sizeof(struct spa_meta_header)));
+    params[1] = reinterpret_cast<const spa_pod*>(spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type,
+                                                                            SPA_POD_Id(SPA_META_Header), SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_header))));
 
-    params[2] = spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoTransform),
-                                           SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_videotransform)));
+    params[2] =
+        reinterpret_cast<const spa_pod*>(spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type,
+                                                                    SPA_POD_Id(SPA_META_VideoTransform), SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_videotransform))));
 
-    params[3] = spa_pod_builder_add_object(&dynBuilder[2].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage), SPA_PARAM_META_size,
-                                           SPA_POD_CHOICE_RANGE_Int(sizeof(struct spa_meta_region) * 4, sizeof(struct spa_meta_region) * 1, sizeof(struct spa_meta_region) * 4));
+    params[3] = reinterpret_cast<const spa_pod*>(
+        spa_pod_builder_add_object(&dynBuilder[2].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage), SPA_PARAM_META_size,
+                                   SPA_POD_CHOICE_RANGE_Int(sizeof(struct spa_meta_region) * 4, sizeof(struct spa_meta_region) * 1, sizeof(struct spa_meta_region) * 4)));
 
     pw_stream_update_params(PSTREAM->stream, params, 4);
     spa_pod_dynamic_builder_clean(&dynBuilder[0]);
@@ -1061,7 +1063,7 @@ uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_p
 
         paramCount = 2;
         params[0]  = build_format(b[0], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoDMA.fmt), stream->pSession->sharingData.frameInfoDMA.w,
-                                 stream->pSession->sharingData.frameInfoDMA.h, stream->pSession->sharingData.framerate, modifiers, modCount);
+                                  stream->pSession->sharingData.frameInfoDMA.h, stream->pSession->sharingData.framerate, modifiers, modCount);
         assert(params[0] != NULL);
         params[1] = build_format(b[1], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoSHM.fmt), stream->pSession->sharingData.frameInfoSHM.w,
                                  stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
@@ -1071,7 +1073,7 @@ uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_p
 
         paramCount = 1;
         params[0]  = build_format(b[0], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoSHM.fmt), stream->pSession->sharingData.frameInfoSHM.w,
-                                 stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
+                                  stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
     }
 
     return paramCount;

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -781,7 +781,7 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param) 
             const spa_pod* pod_modifier = &prop_modifier->value;
 
             uint32_t       n_modifiers = SPA_POD_CHOICE_N_VALUES(pod_modifier) - 1;
-            uint64_t*      modifiers   = reinterpret_cast<uint64_t*>(SPA_POD_CHOICE_VALUES(pod_modifier));
+            uint64_t*      modifiers   = (uint64_t*)SPA_POD_CHOICE_VALUES(pod_modifier);
             modifiers++;
             uint32_t         flags = GBM_BO_USE_RENDERING;
             uint64_t         modifier;
@@ -853,16 +853,15 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param) 
 
     params[0] = build_buffer(&dynBuilder[0].b, blocks, PSTREAM->pSession->sharingData.frameInfoSHM.size, PSTREAM->pSession->sharingData.frameInfoSHM.stride, data_type);
 
-    params[1] = reinterpret_cast<const spa_pod*>(spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type,
-                                                                            SPA_POD_Id(SPA_META_Header), SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_header))));
+    params[1] = (const spa_pod*)spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_Header),
+                                                           SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_header)));
 
-    params[2] =
-        reinterpret_cast<const spa_pod*>(spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type,
-                                                                    SPA_POD_Id(SPA_META_VideoTransform), SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_videotransform))));
+    params[2] = (const spa_pod*)spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoTransform),
+                                                           SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_videotransform)));
 
-    params[3] = reinterpret_cast<const spa_pod*>(
-        spa_pod_builder_add_object(&dynBuilder[2].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage), SPA_PARAM_META_size,
-                                   SPA_POD_CHOICE_RANGE_Int(sizeof(struct spa_meta_region) * 4, sizeof(struct spa_meta_region) * 1, sizeof(struct spa_meta_region) * 4)));
+    params[3] = (const spa_pod*)spa_pod_builder_add_object(
+        &dynBuilder[2].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage), SPA_PARAM_META_size,
+        SPA_POD_CHOICE_RANGE_Int(sizeof(struct spa_meta_region) * 4, sizeof(struct spa_meta_region) * 1, sizeof(struct spa_meta_region) * 4));
 
     pw_stream_update_params(PSTREAM->stream, params, 4);
     spa_pod_dynamic_builder_clean(&dynBuilder[0]);


### PR DESCRIPTION
This PR is  addressing the failing build with clang as described in #81.

To fix the build with clang i added the flag -Wno-address-of-temporary to allow taking temporary addresses as the already existing -fpermissive flag does for gcc.

Furthermore i made some implicit typecasts  explicit that are accepted by gcc but not by clang.
The macro wl_array_for_each, used in PortalManager.cpp, which comes from wayland-utils, had to be implemented inline as it does depend on an implicit typecast that clang does not accept.

If this PR is merged the project can be built with clang and gcc using GNU libstdc++.
I did not test other stdlib implementations.