### PR TITLE
Improve Makefile to match the spec of Hyprland Makefile, and improve installing steps by creating directories beforehand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ all:
 
 release:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -H./ -B./build -G Ninja
-	cmake --build ./build --config Release --target all -j$(nproc)
+	cmake --build ./build --config Release --target all -j`nproc`
 
 debug:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -H./ -B./build -G Ninja
-	cmake --build ./build --config Debug --target all -j$(nproc)
+	cmake --build ./build --config Debug --target all -j`nproc`
 
 install:
 	@if [ ! -f ./build/xdg-desktop-portal-hyprland ]; then echo -e "You need to run $(MAKE) all first.\n" && exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ install:
 	cp -f ./build/hyprland-share-picker/hyprland-share-picker ${PREFIX}/bin
 	cp -f ./build/xdg-desktop-portal-hyprland ${PREFIX}/lib/
 	cp -f ./hyprland.portal ${PREFIX}/share/xdg-desktop-portal/portals/
-	sed "s|@libexecdir@|${PREFIX}/lib|g" ./org.freedesktop.impl.portal.desktop.hyprland.service.in > ${PREFIX}/share/dbus-1/services/org.freedesktop.impl.portal.desktop.hyprland
+	sed "s|@libexecdir@|${PREFIX}/lib|g" ./org.freedesktop.impl.portal.desktop.hyprland.service.in > ${PREFIX}/share/dbus-1/services/org.freedesktop.impl.portal.desktop.hyprland.service
 	sed "s|@libexecdir@|${PREFIX}/lib|g" ./contrib/systemd/xdg-desktop-portal-hyprland.service.in > ${PREFIX}/lib/systemd/user/xdg-desktop-portal-hyprland.service
 	chmod 755 ${PREFIX}/lib/xdg-desktop-portal-hyprland

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ debug:
 
 install:
 	@if [ ! -f ./build/xdg-desktop-portal-hyprland ]; then echo -e "You need to run $(MAKE) all first.\n" && exit 1; fi
-	@echo -en "!NOTE: Please note make install does not compile xdg-desktop-portal-hyprland and only installs the already built files."
+	@echo -en "!NOTE: Please note make install does not compile xdg-desktop-portal-hyprland and only installs the already built files.\n"
 
 	mkdir -p ${PREFIX}/bin
 	mkdir -p ${PREFIX}/lib

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 PREFIX = /usr/local
-LIBEXEC = /usr/lib
-SHARE = /usr/share
 
 all:
+	@if [[ "$EUID" = 0 ]]; then echo -en "Avoid running $(MAKE) all as sudo.\n"; fi
 	$(MAKE) release
 
 release:
@@ -14,10 +13,18 @@ debug:
 	cmake --build ./build --config Debug --target all -j$(nproc)
 
 install:
-	$(MAKE) release
+	@if [ ! -f ./build/xdg-desktop-portal-hyprland ]; then echo -e "You need to run $(MAKE) all first.\n" && exit 1; fi
+	@echo -en "!NOTE: Please note make install does not compile xdg-desktop-portal-hyprland and only installs the already built files."
+
+	mkdir -p ${PREFIX}/bin
+	mkdir -p ${PREFIX}/lib
+	mkdir -p ${PREFIX}/share/xdg-desktop-portal/portals
+	mkdir -p ${PREFIX}/share/dbus-1/services/
+	mkdir -p ${PREFIX}/lib/systemd/user/
+
 	cp -f ./build/hyprland-share-picker/hyprland-share-picker ${PREFIX}/bin
-	cp -f ./build/xdg-desktop-portal-hyprland ${LIBEXEC}/
-	cp -f ./hyprland.portal ${SHARE}/xdg-desktop-portal/portals/
-	sed "s|@libexecdir@|${LIBEXEC}|g" ./org.freedesktop.impl.portal.desktop.hyprland.service.in > ${SHARE}/dbus-1/services/org.freedesktop.impl.portal.desktop.hyprland
-	sed "s|@libexecdir@|${LIBEXEC}|g" ./contrib/systemd/xdg-desktop-portal-hyprland.service.in > ${LIBEXEC}/systemd/user/xdg-desktop-portal-hyprland.service
-	chmod 755 ${LIBEXEC}/xdg-desktop-portal-hyprland
+	cp -f ./build/xdg-desktop-portal-hyprland ${PREFIX}/lib/
+	cp -f ./hyprland.portal ${PREFIX}/share/xdg-desktop-portal/portals/
+	sed "s|@libexecdir@|${PREFIX}/lib|g" ./org.freedesktop.impl.portal.desktop.hyprland.service.in > ${PREFIX}/share/dbus-1/services/org.freedesktop.impl.portal.desktop.hyprland
+	sed "s|@libexecdir@|${PREFIX}/lib|g" ./contrib/systemd/xdg-desktop-portal-hyprland.service.in > ${PREFIX}/lib/systemd/user/xdg-desktop-portal-hyprland.service
+	chmod 755 ${PREFIX}/lib/xdg-desktop-portal-hyprland


### PR DESCRIPTION
EDIT: Converted to draft because there are a lot of missing steps compared to Meson, such as described in #95 

TODO:
- `${PREFIX}/share/pkgconfig/hyprland-protocols.pc`
- `${PREFIX}/share/hyprland-protocols/protocols/hyprland-global-shortcuts-v1.xml`
- `${PREFIX}/share/hyprland-protocols/protocols/hyprland-toplevel-export-v1.xml`

### Why?
My original goal for this MR was not to actually match Hyprland's Makefile, that was more of a "eh, why not" decision. My main goal was to add some `mkdir -p` to the installation task so that copying the various build artifacts would succeed in cases of package managers.

I've created and maintain a separate PKGBUILD for Arch Linux that builds this portal, and time and time again I've been forced to use the meson because the current Makefile does not create the directories but rather assumes they exist. Obviously this isn't a fault of the Makefile, since in a reasonable system with all the correct dependencies these files would already exist, but it leaves problems for when I need to create the file system hierarchy in an isolated packaging environment.

### What's changed?
- Removed LIBEXEC and SHARE and replaced them with `${PREFIX}/lib` and `${PREFIX}/share` (if this breaks intended behavior, I will revert this change)
- Add a `EUID` check for `make all`, similar to [Hyprland's Makefile](https://github.com/Frontear/Hyprland/blob/main/Makefile#L29)
- Add `test -f` check in `make install`, similar to [Hyprland's Makefile](https://github.com/Frontear/Hyprland/blob/main/Makefile#L34)
- Add `mkdir -p` for the various directories used for installing the build artifacts
- **NEW**: Noticed nproc was not correctly being parsed and changed to correctly parse it for parallel jobs
- **NEW**: Fixed a missing `.service` extension when copying `./org.freedesktop.impl.portal.desktop.hyprland.service.in`

### Ready to merge?
Not yet