### PR TITLE
nix: default meson build type to release

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -20,6 +20,7 @@
   slurp,
   hyprland-protocols,
   wayland,
+  debug ? false,
   version ? "git",
 }:
 stdenv.mkDerivation {
@@ -27,6 +28,11 @@ stdenv.mkDerivation {
   inherit version;
 
   src = ../.;
+
+  mesonBuildType =
+    if debug
+    then "debug"
+    else "release";
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
Default build type is `plain`, we want to use `release`.