### PR TITLE
Destroy pipewire streams when ScreenCast sessions are closed

### DIFF
--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -299,7 +299,14 @@ void CScreencopyPortal::onCreateSession(sdbus::MethodCall& call) {
 
     // create objects
     PSESSION->session            = createDBusSession(sessionHandle);
-    PSESSION->session->onDestroy = [PSESSION]() { PSESSION->session.release(); };
+    PSESSION->session->onDestroy = [PSESSION, this]() {
+        if (PSESSION->sharingData.active) {
+            m_pPipewire->destroyStream(PSESSION);
+            Debug::log(LOG, "[screencopy] Stream destroyed");
+        }
+        PSESSION->session.release();
+        Debug::log(LOG, "[screencopy] Session destroyed");
+    };
     PSESSION->request            = createDBusRequest(requestHandle);
     PSESSION->request->onDestroy = [PSESSION]() { PSESSION->request.release(); };
 

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -988,6 +988,12 @@ void CPipewireConnection::createStream(CScreencopyPortal::SSession* pSession) {
 }
 
 void CPipewireConnection::destroyStream(CScreencopyPortal::SSession* pSession) {
+    // Disconnecting the stream can cause reentrance to this function.
+    if (pSession->sharingData.active == false) {
+        return;
+    }
+    pSession->sharingData.active = false;
+
     const auto PSTREAM = streamFromSession(pSession);
 
     if (!PSTREAM || !PSTREAM->stream)
@@ -1002,8 +1008,6 @@ void CPipewireConnection::destroyStream(CScreencopyPortal::SSession* pSession) {
     pw_stream_flush(PSTREAM->stream, false);
     pw_stream_disconnect(PSTREAM->stream);
     pw_stream_destroy(PSTREAM->stream);
-
-    pSession->sharingData.active = false;
 
     std::erase_if(m_vStreams, [&](const auto& other) { return other.get() == PSTREAM; });
 }
@@ -1065,7 +1069,7 @@ uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_p
 
         paramCount = 2;
         params[0]  = build_format(b[0], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoDMA.fmt), stream->pSession->sharingData.frameInfoDMA.w,
-                                 stream->pSession->sharingData.frameInfoDMA.h, stream->pSession->sharingData.framerate, modifiers, modCount);
+                                  stream->pSession->sharingData.frameInfoDMA.h, stream->pSession->sharingData.framerate, modifiers, modCount);
         assert(params[0] != NULL);
         params[1] = build_format(b[1], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoSHM.fmt), stream->pSession->sharingData.frameInfoSHM.w,
                                  stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
@@ -1075,7 +1079,7 @@ uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_p
 
         paramCount = 1;
         params[0]  = build_format(b[0], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoSHM.fmt), stream->pSession->sharingData.frameInfoSHM.w,
-                                 stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
+                                  stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
     }
 
     if (modifiers)

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -996,9 +996,8 @@ void CPipewireConnection::createStream(CScreencopyPortal::SSession* pSession) {
 
 void CPipewireConnection::destroyStream(CScreencopyPortal::SSession* pSession) {
     // Disconnecting the stream can cause reentrance to this function.
-    if (pSession->sharingData.active == false) {
+    if (pSession->sharingData.active == false)
         return;
-    }
     pSession->sharingData.active = false;
 
     const auto PSTREAM = streamFromSession(pSession);


### PR DESCRIPTION
The current implementation never closes PipeWire streams after their sessions are closed. This PR adds a call to `destroyStream` to `session->onDestroy`.

I also made changes to `destroyStream` because it seems to reenter itself and cause a double free.