### PR TITLE
cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-client wayland-protocols
 pkg_check_modules(SDBUS IMPORTED_TARGET sdbus-c++)
 if(NOT SDBUS_FOUND)
     include_directories("subprojects/sdbus-cpp/include/")
-    add_subdirectory(subprojects/sdbus-cpp)
+    add_subdirectory(subprojects/sdbus-cpp EXCLUDE_FROM_ALL)
     add_library(PkgConfig::SDBUS ALIAS sdbus-c++)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,4 +104,4 @@ install(TARGETS xdg-desktop-portal-hyprland DESTINATION ${CMAKE_INSTALL_LIBEXECD
 
 install(FILES hyprland.portal DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/xdg-desktop-portal/portals")
 install(FILES ${CMAKE_BINARY_DIR}/org.freedesktop.impl.portal.desktop.hyprland.service DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/dbus-1/services")
-install(FILES ${CMAKE_BINARY_DIR}/contrib/systemd/xdg-desktop-portal-hyprland.service DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/user")
+install(FILES ${CMAKE_BINARY_DIR}/contrib/systemd/xdg-desktop-portal-hyprland.service DESTINATION "lib/systemd/user")


### PR DESCRIPTION
- Cmake: Do not use CMAKE_INSTALL_LIBDIR for the systemd service
- cmake: Don't install sdbus-cpp files
