### PR TITLE
picker: Adds elided buttons for better readability

### DIFF
--- a/hyprland-share-picker/CMakeLists.txt
+++ b/hyprland-share-picker/CMakeLists.txt
@@ -17,6 +17,8 @@ set(PROJECT_SOURCES
         mainpicker.cpp
         mainpicker.h
         mainpicker.ui
+        elidedbutton.h
+        elidedbutton.cpp
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)

--- a/hyprland-share-picker/elidedbutton.cpp
+++ b/hyprland-share-picker/elidedbutton.cpp
@@ -1,0 +1,31 @@
+#include "elidedbutton.h"
+
+ElidedButton::ElidedButton(QWidget *parent)
+    : QPushButton(parent)
+{
+}
+
+ElidedButton::ElidedButton( const QString& text, QWidget* parent )
+    : ElidedButton( parent )
+{
+    setText(text);
+}
+
+void ElidedButton::setText(QString text)
+{
+    og_text = text;
+    updateText();
+}
+
+void ElidedButton::resizeEvent(QResizeEvent *event)
+{
+    QPushButton::resizeEvent(event);
+    updateText();
+}
+
+void ElidedButton::updateText()
+{
+    QFontMetrics metrics(font());
+    QString elided = metrics.elidedText(og_text, Qt::ElideRight, width() - 15);
+    QPushButton::setText(elided);
+}

--- a/hyprland-share-picker/elidedbutton.h
+++ b/hyprland-share-picker/elidedbutton.h
@@ -1,0 +1,21 @@
+#ifndef ELIDEDBUTTON_H
+#define ELIDEDBUTTON_H
+
+#include <QPushButton>
+
+class ElidedButton : public QPushButton
+{
+public:
+    explicit ElidedButton(QWidget *parent = nullptr);
+    explicit ElidedButton(const QString &text, QWidget *parent = nullptr);
+    void setText(QString);
+
+protected:
+    void resizeEvent(QResizeEvent *);
+
+private:
+    void updateText();
+    QString og_text;
+};
+
+#endif // ELIDEDBUTTON_H

--- a/hyprland-share-picker/main.cpp
+++ b/hyprland-share-picker/main.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "mainpicker.h"
+#include "elidedbutton.h"
 
 std::string execAndGet(const char* cmd) {
     std::array<char, 128>                    buffer;
@@ -110,9 +111,10 @@ int main(int argc, char* argv[]) {
         QString      text = QString::fromStdString(std::string("Screen " + std::to_string(i) + " at " + std::to_string(GEOMETRY.x()) + ", " + std::to_string(GEOMETRY.y()) + " (" +
                                                           std::to_string(GEOMETRY.width()) + "x" + std::to_string(GEOMETRY.height()) + ") (") +
                                               SCREENS[i]->name().toStdString() + ")");
-        QPushButton* button = new QPushButton(text);
-        SCREENS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);
+        ElidedButton* button = new ElidedButton(text);
         button->setMinimumSize(0, BUTTON_HEIGHT);
+        SCREENS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);
+
         QObject::connect(button, &QPushButton::clicked, [=]() {
             std::string ID = button->text().toStdString();
             ID             = ID.substr(ID.find_last_of('(') + 1);
@@ -147,9 +149,9 @@ int main(int argc, char* argv[]) {
     for (auto& window : WINDOWLIST) {
         QString      text = QString::fromStdString(window.clazz + ": " + window.name);
 
-        QPushButton* button = new QPushButton(text);
-        WINDOWS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);
+        ElidedButton* button = new ElidedButton(text);
         button->setMinimumSize(0, BUTTON_HEIGHT);
+        WINDOWS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);
 
         mainPickerPtr->windowIDs[button] = window.id;
 
@@ -179,16 +181,11 @@ int main(int argc, char* argv[]) {
     const auto   REGION_LAYOUT = REGION_OBJECT->layout();
 
     QString      text = "Select region...";
-
-    QSpacerItem * REGION_L_SPACER = new QSpacerItem(10000,0, QSizePolicy::Expanding, QSizePolicy::Expanding);
-    QSpacerItem * REGION_R_SPACER = new QSpacerItem(10000,0, QSizePolicy::Expanding, QSizePolicy::Expanding);
     
-    REGION_LAYOUT->addItem(REGION_L_SPACER);
-    
-    QPushButton* button = new QPushButton(text);
+    ElidedButton* button = new ElidedButton(text);
+    button->setMaximumSize(400, BUTTON_HEIGHT);
     REGION_LAYOUT->addWidget(button);
 
-    REGION_LAYOUT->addItem(REGION_R_SPACER);
 
     QObject::connect(button, &QPushButton::clicked, [=]() {
         auto REGION = execAndGet("slurp -f \"%o %x %y %w %h\"");

--- a/hyprland-share-picker/mainpicker.ui
+++ b/hyprland-share-picker/mainpicker.ui
@@ -232,8 +232,8 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>730</width>
-           <height>224</height>
+           <width>16777215</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="layoutDirection">
@@ -245,7 +245,7 @@
          <attribute name="title">
           <string>Region</string>
          </attribute>
-         <layout class="QHBoxLayout" name="horizontalLayout">
+         <layout class="QGridLayout" name="gridLayout">
           <property name="sizeConstraint">
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>


### PR DESCRIPTION
It also fixes the region button size and alignment

fixes [#175](https://github.com/hyprwm/xdg-desktop-portal-hyprland/issues/175#issuecomment-1913815879)

The reason of this PR is because i was having elided text in buttons because my theme
Now the elided text in buttons is on purpose

Before: See second element (image taken from #175)    
![image](https://github.com/hyprwm/xdg-desktop-portal-hyprland/assets/6665402/8b59dc0a-5ec8-4592-9e41-48e073677173)

After:    
![image](https://github.com/hyprwm/xdg-desktop-portal-hyprland/assets/6665402/c173bd76-4fad-4a97-955f-7e1bbab6bb57)

Ignore the theme, i forgot to take screenshot before doing the work