### PR TITLE
Hardcoded cmake /usr/lib/xdph path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,6 @@ include_directories(
 # configure
 include(GNUInstallDirs)
 set(LIBEXECDIR ${CMAKE_INSTALL_FULL_LIBEXECDIR})
-configure_file(org.freedesktop.impl.portal.desktop.hyprland.service.in org.freedesktop.impl.portal.desktop.hyprland.service @ONLY)
-configure_file(contrib/systemd/xdg-desktop-portal-hyprland.service.in contrib/systemd/xdg-desktop-portal-hyprland.service @ONLY)
 
 set(CMAKE_CXX_STANDARD 23)
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value

--- a/contrib/systemd/xdg-desktop-portal-hyprland.service
+++ b/contrib/systemd/xdg-desktop-portal-hyprland.service
@@ -7,6 +7,6 @@ ConditionEnvironment=WAYLAND_DISPLAY
 [Service]
 Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.hyprland
-ExecStart=@LIBEXECDIR@/xdg-desktop-portal-hyprland
+ExecStart=/usr/lib/xdg-desktop-portal-hyprland
 Restart=on-failure
 Slice=session.slice

--- a/org.freedesktop.impl.portal.desktop.hyprland.service.in
+++ b/org.freedesktop.impl.portal.desktop.hyprland.service.in
@@ -1,4 +1,0 @@
-[D-BUS Service]
-Name=org.freedesktop.impl.portal.desktop.hyprland
-Exec=@LIBEXECDIR@/xdg-desktop-portal-hyprland
-SystemdService=xdg-desktop-portal-hyprland.service


### PR DESCRIPTION
This modifies a couple of files to use `/usr/lib/xdg-desktop-portal-hyprland` when trying to run the portan instead of `@LIBEXECDIR@/xdg-desktop-portal-hyprland`.

This is because the directory the initial executable is placed in won't always correspond to where the final one ends up being, e.g. when installing an aur package (this pr would fix the [xdg-desktop-portal-hyprland-git](https://aur.archlinux.org/packages/xdg-desktop-portal-hyprland-git) aur package).

I am not sure if there are any other cases, where the cmake substitution is necessary.