### PR TITLE
core: reset screenshot pointer aswell

### DIFF
--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -482,6 +482,7 @@ void CPortalManager::startEventLoop() {
 
     m_sPortals.globalShortcuts.reset();
     m_sPortals.screencopy.reset();
+    m_sPortals.screenshot.reset();
 
     m_pConnection.reset();
     pw_loop_destroy(m_sPipewire.loop);


### PR DESCRIPTION
ensure the screenshot portal is destructed before the connection is down, otherwise it segfaults inside sdbus.

fixes #208 