### PR TITLE
fix : inShellPath, Permission denied

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -56,7 +56,7 @@ bool inShellPath(const std::string& exec) {
     if (nextBegin < pathString.size())
         paths.push_back(pathString.substr(nextBegin, pathString.size() - nextBegin));
 
-    return std::ranges::any_of(paths, [&exec](std::string& path) { return std::filesystem::exists(path + "/" + exec); });
+    return std::ranges::any_of(paths, [&exec](std::string& path) { return access((path + "/" + exec).c_str(), X_OK) == 0; });
 }
 
 void sendEmptyDbusMethodReply(sdbus::MethodCall& call, u_int32_t responseCode) {


### PR DESCRIPTION
In certain unusual scenarios where the $PATH starts or contains a directory inaccessible to the user, running "/usr/lib/xdg-desktop-portal-hyprland" may produce the following error:

```
#PATH=/root/.local/bin:/root/go/bin:/home/v3llocet/.local/bin...
what(): filesystem error: status: Permission denied [/root/.local/bin/grim]
/home/v3llocet/.config/hypr/xdg: line 7: 6807 Aborted (core dumped) /usr/lib/xdg-desktop-portal-hyprland
```

This error occurs because the function "std::filesystem::exists" breaks when encountering such an error. To address this issue, I propose replacing it with "access" which can verify permissions and return true if the executable exists.