### PR TITLE
hacky fix for fixing output screencopy

### DIFF
--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -8,6 +8,8 @@
 #include <protocols/linux-dmabuf-unstable-v1-protocol.h>
 #include <unistd.h>
 
+constexpr static int MAX_RETRIES = 10;
+
 // --------------- Wayland Protocol Handlers --------------- //
 
 static void wlrOnBuffer(void* data, zwlr_screencopy_frame_v1* frame, uint32_t format, uint32_t width, uint32_t height, uint32_t stride) {
@@ -128,8 +130,8 @@ static void wlrOnBufferDone(void* data, zwlr_screencopy_frame_v1* frame) {
         PSESSION->sharingData.frameCallback = nullptr;
         Debug::log(LOG, "[screencopy/pipewire] Out of buffers");
         PSESSION->sharingData.status = FRAME_NONE;
-        if (PSESSION->sharingData.copyRetries++ < 6) {
-            Debug::log(LOG, "[sc] Retrying screencopy ({}/6)", PSESSION->sharingData.copyRetries);
+        if (PSESSION->sharingData.copyRetries++ < MAX_RETRIES) {
+            Debug::log(LOG, "[sc] Retrying screencopy ({}/{})", PSESSION->sharingData.copyRetries, MAX_RETRIES);
             g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
             g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(PSESSION);
         }

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -128,6 +128,8 @@ static void wlrOnBufferDone(void* data, zwlr_screencopy_frame_v1* frame) {
         PSESSION->sharingData.frameCallback = nullptr;
         Debug::log(LOG, "[screencopy/pipewire] Out of buffers");
         PSESSION->sharingData.status = FRAME_NONE;
+        g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
+        g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(PSESSION);
         return;
     }
 

--- a/src/portals/Screencopy.hpp
+++ b/src/portals/Screencopy.hpp
@@ -81,6 +81,7 @@ class CScreencopyPortal {
             uint32_t                              framerate           = 60;
             wl_output_transform                   transform           = WL_OUTPUT_TRANSFORM_NORMAL;
             std::chrono::system_clock::time_point begunFrame          = std::chrono::system_clock::now();
+            uint32_t                              copyRetries         = 0;
 
             struct {
                 uint32_t w = 0, h = 0, size = 0, stride = 0, fmt = 0;


### PR DESCRIPTION
Very hacky fix to make screencopy continue capturing frames after `Out of buffers` error occurs.

PR as requested in #247 