### PR TITLE
CMakeLists: just search for the wayland-scanner binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ pkg_check_modules(
   IMPORTED_TARGET
   wayland-client
   wayland-protocols
-  wayland-scanner
   libpipewire-0.3>=1.1.82
   libspa-0.2
   libdrm
@@ -87,7 +86,7 @@ target_link_libraries(
                                       PkgConfig::deps)
 
 # protocols
-pkg_get_variable(WaylandScanner wayland-scanner wayland_scanner)
+find_program(WaylandScanner NAMES wayland-scanner)
 message(STATUS "Found WaylandScanner at ${WaylandScanner}")
 pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
 message(STATUS "Found wayland-protocols at ${WAYLAND_PROTOCOLS_DIR}")


### PR DESCRIPTION
Otherwise after https://github.com/NixOS/nixpkgs/pull/214906 you get:

```
xdg-desktop-portal-hyprland> CMake Error in CMakeLists.txt:
xdg-desktop-portal-hyprland>   Imported target "PkgConfig::deps" includes non-existent path
xdg-desktop-portal-hyprland>     "/nix/store/0ikl83z4h69imxkwsly3hcm424f7wi7j-wayland-scanner-1.23.0-dev/include"
xdg-desktop-portal-hyprland>   in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:
xdg-desktop-portal-hyprland>   * The path was deleted, renamed, or moved to another location.
xdg-desktop-portal-hyprland>   * An install or uninstall procedure did not complete successfully.
xdg-desktop-portal-hyprland>   * The installation package was faulty and references files it does not
xdg-desktop-portal-hyprland>   provide.
```