### PR TITLE
Readded call to toplevel activate function in onCreateSession

### DIFF
--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -34,6 +34,8 @@ static sdbus::Struct<std::string, uint32_t, sdbus::Variant> getFullRestoreStruct
 
 dbUasv CScreencopyPortal::onCreateSession(sdbus::ObjectPath requestHandle, sdbus::ObjectPath sessionHandle, std::string appID,
                                           std::unordered_map<std::string, sdbus::Variant> opts) {
+    g_pPortalManager->m_sHelpers.toplevel->activate();
+
     Debug::log(LOG, "[screencopy] New session:");
     Debug::log(LOG, "[screencopy]  | {}", requestHandle.c_str());
     Debug::log(LOG, "[screencopy]  | {}", sessionHandle.c_str());


### PR DESCRIPTION
I think this line might have accidentally been removed in the sdbus 2.0 migration PR after I added it back in the screensharing windows worked fine for me.