### PR TITLE
nix: overlays: xdph: override sdbus with sdbus-cpp_2 (closes #286)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
     overlays = import ./nix/overlays.nix {inherit self inputs lib;};
 
     packages = eachSystem (system: {
-      inherit (pkgsFor.${system}) xdg-desktop-portal-hyprland;
+      inherit (pkgsFor.${system}) xdg-desktop-portal-hyprland sdbus-cpp_2;
       default = self.packages.${system}.xdg-desktop-portal-hyprland;
     });
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,7 +16,7 @@
   qtbase,
   qttools,
   qtwayland,
-  sdbus-cpp,
+  sdbus-cpp_2,
   slurp,
   systemd,
   wayland,
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     qtbase
     qttools
     qtwayland
-    sdbus-cpp
+    sdbus-cpp_2
     systemd
     wayland
     wayland-protocols

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -22,8 +22,8 @@ in {
     inputs.hyprland-protocols.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
-    self.overlays.sdbuscpp
   ]);
+
   xdg-desktop-portal-hyprland = lib.composeManyExtensions [
     (final: prev: {
       xdg-desktop-portal-hyprland = final.callPackage ./default.nix {
@@ -34,14 +34,26 @@ in {
     })
   ];
 
-  sdbuscpp = final: prev: {
-    sdbus-cpp = prev.sdbus-cpp.overrideAttrs (self: super: {
+  # If `prev` already contains `sdbus-cpp_2`, do not modify the package set.
+  # If the previous fixpoint does not contain the attribute,
+  # create a new package attribute, `sdbus-cpp_2` by overriding `sdbus-cpp`
+  # from `final` with the new version of `src`.
+  #
+  # This matches the naming/versioning scheme used in `nixos-unstable` as of writing (10-27-2024).
+  #
+  # This overlay can be applied to either a stable release of Nixpkgs, or any of the unstable branches.
+  # If you're using an unstable branch (or a release one) which already has `sdbus-cpp_2`,
+  # this overlay is effectively a wrapper of an identity function.
+  #
+  # TODO: Remove this overlay after the next stable Nixpkgs release.
+  sdbus-cpp_2 = final: prev: {
+    sdbus-cpp_2 = prev.sdbus-cpp_2 or final.sdbus-cpp.overrideAttrs (self: _: {
       version = "2.0.0";
 
       src = final.fetchFromGitHub {
         owner = "Kistler-group";
         repo = "sdbus-cpp";
-        rev = "refs/tags/v${self.version}";
+        rev = "v${self.version}";
         hash = "sha256-W8V5FRhV3jtERMFrZ4gf30OpIQLYoj2yYGpnYOmH2+g=";
       };
     });

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -22,6 +22,7 @@ in {
     inputs.hyprland-protocols.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
+    self.overlays.sdbus-cpp_2
   ]);
 
   xdg-desktop-portal-hyprland = lib.composeManyExtensions [


### PR DESCRIPTION
In the default overlay, override XDPH's package arguments to say that `sdbus-cpp = sdbus-cpp_2` which was introduced in a prior commit.

Let's discuss in #286.

This PR is my preference, until we do more digging in Nixpkgs to see if `sdbus-cpp_2` is a permanent name, or if they're phasing it out once other package updates are merged.