### PR TITLE
nix: package: replace sdbus-cpp with sdbus-cpp_2 (closes #286)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
     overlays = import ./nix/overlays.nix {inherit self inputs lib;};
 
     packages = eachSystem (system: {
-      inherit (pkgsFor.${system}) xdg-desktop-portal-hyprland;
+      inherit (pkgsFor.${system}) xdg-desktop-portal-hyprland sdbus-cpp_2;
       default = self.packages.${system}.xdg-desktop-portal-hyprland;
     });
 

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -22,8 +22,8 @@ in {
     inputs.hyprland-protocols.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
-    self.overlays.sdbuscpp
   ]);
+
   xdg-desktop-portal-hyprland = lib.composeManyExtensions [
     (final: prev: {
       xdg-desktop-portal-hyprland = final.callPackage ./default.nix {
@@ -34,14 +34,26 @@ in {
     })
   ];
 
-  sdbuscpp = final: prev: {
-    sdbus-cpp = prev.sdbus-cpp.overrideAttrs (self: super: {
+  # If `prev` already contains `sdbus-cpp_2`, do not modify the package set.
+  # If the previous fixpoint does not contain the attribute,
+  # create a new package attribute, `sdbus-cpp_2` by overriding `sdbus-cpp`
+  # from `final` with the new version of `src`.
+  #
+  # This matches the naming/versioning scheme used in `nixos-unstable` as of writing (10-27-2024).
+  #
+  # This overlay can be applied to either a stable release of Nixpkgs, or any of the unstable branches.
+  # If you're using an unstable branch (or a release one) which already has `sdbus-cpp_2`,
+  # this overlay is effectively a wrapper of an identity function.
+  #
+  # TODO: Remove this overlay after the next stable Nixpkgs release.
+  sdbus-cpp_2 = final: prev: {
+    sdbus-cpp_2 = prev.sdbus-cpp_2 or final.sdbus-cpp.overrideAttrs (self: _: {
       version = "2.0.0";
 
       src = final.fetchFromGitHub {
         owner = "Kistler-group";
         repo = "sdbus-cpp";
-        rev = "refs/tags/v${self.version}";
+        rev = "v${self.version}";
         hash = "sha256-W8V5FRhV3jtERMFrZ4gf30OpIQLYoj2yYGpnYOmH2+g=";
       };
     });

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -22,12 +22,14 @@ in {
     inputs.hyprland-protocols.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
+    self.overlays.sdbus-cpp_2
   ]);
 
   xdg-desktop-portal-hyprland = lib.composeManyExtensions [
     (final: prev: {
       xdg-desktop-portal-hyprland = final.callPackage ./default.nix {
         stdenv = prev.gcc13Stdenv;
+        sdbus-cpp = final.sdbus-cpp_2;
         inherit (final.qt6) qtbase qttools wrapQtAppsHook qtwayland;
         inherit version;
       };


### PR DESCRIPTION
Replace XDPH's package argument `sdbus-cpp` with `sdbus-cpp_2`.

This is my less preferred option.

Let's discuss in #286.

Also see #287.

This PR should be merged over that one in the event that `sdbus-cpp_2` is a permanent addition to Nixpkgs (and `sdbus-cpp` stays for dependents on `1.5.x`).