### PR TITLE
housekeeping: nix/overlays.nix (closes #285)

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -5,9 +5,6 @@
 }: let
   ver = lib.removeSuffix "\n" (builtins.readFile ../VERSION);
 
-  mkJoinedOverlays = overlays: final: prev:
-    lib.foldl' (attrs: overlay: attrs // (overlay final prev)) {} overlays;
-
   mkDate = longDate: (lib.concatStringsSep "-" [
     (builtins.substring 0 4 longDate)
     (builtins.substring 4 2 longDate)
@@ -16,7 +13,7 @@
 
   version = ver + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
 in {
-  default = mkJoinedOverlays (with self.overlays; [
+  default = lib.composeManyExtensions (with self.overlays; [
     xdg-desktop-portal-hyprland
     inputs.hyprlang.overlays.default
     inputs.hyprland-protocols.overlays.default

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -13,14 +13,14 @@
 
   version = ver + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
 in {
-  default = lib.composeManyExtensions (with self.overlays; [
-    xdg-desktop-portal-hyprland
+  default = lib.composeManyExtensions [
+    self.overlays.xdg-desktop-portal-hyprland
     inputs.hyprlang.overlays.default
     inputs.hyprland-protocols.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
     self.overlays.sdbus-cpp_2
-  ]);
+  ];
 
   xdg-desktop-portal-hyprland = lib.composeManyExtensions [
     (final: prev: {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -13,13 +13,14 @@
 
   version = ver + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
 in {
+  # List dependencies in ascending order with respect to usage (`foldr`).
   default = lib.composeManyExtensions [
     self.overlays.xdg-desktop-portal-hyprland
-    inputs.hyprlang.overlays.default
-    inputs.hyprland-protocols.overlays.default
-    inputs.hyprutils.overlays.default
-    inputs.hyprwayland-scanner.overlays.default
     self.overlays.sdbus-cpp_2
+    inputs.hyprland-protocols.overlays.default
+    inputs.hyprwayland-scanner.overlays.default
+    inputs.hyprlang.overlays.default
+    inputs.hyprutils.overlays.default
   ];
 
   xdg-desktop-portal-hyprland = lib.composeManyExtensions [


### PR DESCRIPTION
- remove `mkJoinedOverlays` function
- remove needless `with`
- change composition order (and add a comment)
