### PR TITLE
gitignore: add nix result and result-man

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,18 +51,21 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-# build folder
+# Build folders
 build/
 build-*/
-
-.cache
-.vscode/
-
 hyprland-share-picker/build/
 
+# Generated code files
 protocols/*.c*
 protocols/*.h*
 
 # Nix build results
 result
 result-man
+
+# Code editors
+.vscode/
+
+# MISCELLANEOUS
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ hyprland-share-picker/build/
 
 protocols/*.c*
 protocols/*.h*
+
+# Nix build results
+result
+result-man


### PR DESCRIPTION
- gitignore: add nix result and result-man

TODO:

- What is `.cache` from, and can it go under any of the existing sections as labeled in comments?
- Should `hyprland-share-picker/build` be moved under the `# build folder` section?
- Can I name the `protocols/*.{c,h}*` patterns as `# generated code`?