### PR TITLE
use stable/linux-dmabuf-v1 instead of unstable/linux-dmabuf-unstable-v1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ protocolnew("${HYPRLAND_PROTOCOLS}/protocols" "hyprland-global-shortcuts-v1"
             true)
 protocolnew("${HYPRLAND_PROTOCOLS}/protocols" "hyprland-toplevel-export-v1"
             true)
-protocolnew("unstable/linux-dmabuf" "linux-dmabuf-unstable-v1" false)
+protocolnew("stable/linux-dmabuf" "linux-dmabuf-v1" false)
 
 # Installation
 install(TARGETS hyprland-share-picker)

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -22,7 +22,7 @@ client_protocols = [
 	'wlr-foreign-toplevel-management-unstable-v1.xml',
 	hl_protocol_dir / 'protocols/hyprland-toplevel-export-v1.xml',
 	hl_protocol_dir / 'protocols/hyprland-global-shortcuts-v1.xml',
-	wl_protocol_dir / 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml',
+	wl_protocol_dir / 'stable/linux-dmabuf/linux-dmabuf-v1.xml',
 ]
 
 wl_proto_files = []

--- a/src/core/PortalManager.hpp
+++ b/src/core/PortalManager.hpp
@@ -15,7 +15,7 @@
 
 #include "hyprland-toplevel-export-v1.hpp"
 #include "hyprland-global-shortcuts-v1.hpp"
-#include "linux-dmabuf-unstable-v1.hpp"
+#include "linux-dmabuf-v1.hpp"
 #include "wlr-foreign-toplevel-management-unstable-v1.hpp"
 #include "wlr-screencopy-unstable-v1.hpp"
 

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -5,7 +5,7 @@
 
 #include <libdrm/drm_fourcc.h>
 #include <pipewire/pipewire.h>
-#include "linux-dmabuf-unstable-v1.hpp"
+#include "linux-dmabuf-v1.hpp"
 #include <unistd.h>
 
 constexpr static int MAX_RETRIES = 10;


### PR DESCRIPTION
It shouldn't break anything, at least it works for me with chromium and obs.