### PR TITLE
nix/overlays: gcc13 -> gcc14

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -26,7 +26,7 @@ in {
   xdg-desktop-portal-hyprland = lib.composeManyExtensions [
     (final: prev: {
       xdg-desktop-portal-hyprland = final.callPackage ./default.nix {
-        stdenv = prev.gcc13Stdenv;
+        stdenv = prev.gcc14Stdenv;
         inherit (final.qt6) qtbase qttools wrapQtAppsHook qtwayland;
         inherit version;
       };


### PR DESCRIPTION
Follow up to https://github.com/hyprwm/Hyprland/pull/8738

Moves nix overlay build to gcc14 so we can update flake in hyprland to fix it there. 