### PR TITLE
core: move wayland event reading to the poll thread plus cleanup

### DIFF
--- a/src/core/PortalManager.hpp
+++ b/src/core/PortalManager.hpp
@@ -106,6 +106,9 @@ class CPortalManager {
         std::mutex              loopMutex;
         std::atomic<bool>       shouldProcess = false;
         std::mutex              loopRequestMutex;
+
+        std::condition_variable wlDispatchCV;
+        bool                    wlDispatched = false;
     } m_sEventLoopInternals;
 
     struct {

--- a/src/core/PortalManager.hpp
+++ b/src/core/PortalManager.hpp
@@ -109,20 +109,17 @@ class CPortalManager {
 
         std::condition_variable wlDispatchCV;
         bool                    wlDispatched = false;
+
+        std::mutex              timersMutex;
+        std::condition_variable timerRequestCV;
+        std::mutex              timerRequestMutex;
+        bool                    timerEvent = false;
     } m_sEventLoopInternals;
 
-    struct {
-        std::condition_variable              loopSignal;
-        std::mutex                           loopMutex;
-        bool                                 shouldProcess = false;
-        std::vector<std::unique_ptr<CTimer>> timers;
-        std::unique_ptr<std::thread>         thread;
-    } m_sTimersThread;
+    std::vector<std::unique_ptr<CTimer>>  m_timers;
 
     std::unique_ptr<sdbus::IConnection>   m_pConnection;
     std::vector<std::unique_ptr<SOutput>> m_vOutputs;
-
-    std::mutex                            m_mEventLock;
 };
 
 inline std::unique_ptr<CPortalManager> g_pPortalManager;


### PR DESCRIPTION
This implements https://github.com/hyprwm/hyprlock/pull/655 but here in xdph.

It might improve the experience on nvidia cards, but unsure if that's really the case.

The second commit does some cleanup regarding timers.
Removes this `m_mEventMutex` and instead uses a resource specific mutex for the timers.
Also locks the timers mutex when we add a new timer potentially fixing some races.

So far I only tested screensharing.