### PR TITLE
[RFC] picker: Draw diagram of screens

### DIFF
--- a/hyprland-share-picker/CMakeLists.txt
+++ b/hyprland-share-picker/CMakeLists.txt
@@ -25,7 +25,7 @@ pkg_check_modules(
   hyprutils>=0.2.6)
 
 set(PROJECT_SOURCES main.cpp mainpicker.cpp mainpicker.h mainpicker.ui
-                    elidedbutton.h elidedbutton.cpp)
+                    elidedbutton.h elidedbutton.cpp screenview.h screenview.cpp)
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
   qt_add_executable(hyprland-share-picker MANUAL_FINALIZATION

--- a/hyprland-share-picker/main.cpp
+++ b/hyprland-share-picker/main.cpp
@@ -20,6 +20,7 @@ using namespace Hyprutils::OS;
 
 #include "mainpicker.h"
 #include "elidedbutton.h"
+#include "screenview.h"
 
 std::string execAndGet(const char* cmd) {
     std::string command = cmd + std::string{" 2>&1"};
@@ -102,45 +103,17 @@ int main(int argc, char* argv[]) {
 
     const auto TAB1 = (QWidget*)TABWIDGET->children()[0];
 
-    const auto SCREENS_SCROLL_AREA_CONTENTS =
-        (QWidget*)TAB1->findChild<QWidget*>("screens")->findChild<QScrollArea*>("scrollArea")->findChild<QWidget*>("scrollAreaWidgetContents");
+    const auto SCREENS_WIDGET = (QWidget*)TAB1->findChild<QWidget*>("screens");
 
-    const auto SCREENS_SCROLL_AREA_CONTENTS_LAYOUT = SCREENS_SCROLL_AREA_CONTENTS->layout();
+    auto       SCREENVIEW = new ScreenView();
+    SCREENS_WIDGET->layout()->addWidget(SCREENVIEW);
+    SCREENVIEW->activate(pickerPtr, ALLOWTOKENBUTTON, settings, mainPickerPtr);
+    SCREENVIEW->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     // add all screens
     const auto    SCREENS = picker.screens();
 
     constexpr int BUTTON_HEIGHT = 41;
-
-    for (int i = 0; i < SCREENS.size(); ++i) {
-        const auto    GEOMETRY = SCREENS[i]->geometry();
-
-        QString       text = QString::fromStdString(std::string("Screen " + std::to_string(i) + " at " + std::to_string(GEOMETRY.x()) + ", " + std::to_string(GEOMETRY.y()) + " (" +
-                                                                std::to_string(GEOMETRY.width()) + "x" + std::to_string(GEOMETRY.height()) + ") (") +
-                                                    SCREENS[i]->name().toStdString() + ")");
-        QString       outputName = SCREENS[i]->name();
-        ElidedButton* button     = new ElidedButton(text);
-        button->setMinimumSize(0, BUTTON_HEIGHT);
-        SCREENS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);
-
-        QObject::connect(button, &QPushButton::clicked, [=]() {
-            std::cout << "[SELECTION]";
-            std::cout << (ALLOWTOKENBUTTON->isChecked() ? "r" : "");
-            std::cout << "/";
-
-            std::cout << "screen:" << outputName.toStdString() << "\n";
-
-            settings->setValue("width", mainPickerPtr->width());
-            settings->setValue("height", mainPickerPtr->height());
-            settings->sync();
-
-            pickerPtr->quit();
-            return 0;
-        });
-    }
-
-    QSpacerItem* SCREENS_SPACER = new QSpacerItem(0, 10000, QSizePolicy::Expanding, QSizePolicy::Expanding);
-    SCREENS_SCROLL_AREA_CONTENTS_LAYOUT->addItem(SCREENS_SPACER);
 
     // windows
     const auto WINDOWS_SCROLL_AREA_CONTENTS =

--- a/hyprland-share-picker/mainpicker.ui
+++ b/hyprland-share-picker/mainpicker.ui
@@ -98,75 +98,7 @@
          <attribute name="title">
           <string>Screen</string>
          </attribute>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="0">
-           <widget class="QScrollArea" name="scrollArea">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::NoFocus</enum>
-            </property>
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QAbstractScrollArea::AdjustIgnored</enum>
-            </property>
-            <property name="widgetResizable">
-             <bool>true</bool>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-            </property>
-            <widget class="QWidget" name="scrollAreaWidgetContents">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>0</y>
-               <width>410</width>
-               <height>18</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Ignored" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="focusPolicy">
-              <enum>Qt::NoFocus</enum>
-             </property>
-             <layout class="QVBoxLayout" name="screensScrollAreaLayout">
-              <property name="spacing">
-               <number>6</number>
-              </property>
-              <property name="sizeConstraint">
-               <enum>QLayout::SetDefaultConstraint</enum>
-              </property>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-         </layout>
+         <layout class="QGridLayout" name="gridLayout_2"/>
         </widget>
         <widget class="QWidget" name="windows">
          <property name="sizePolicy">

--- a/hyprland-share-picker/meson.build
+++ b/hyprland-share-picker/meson.build
@@ -12,6 +12,8 @@ sources = files([
   'mainpicker.h',
   'elidedbutton.h',
   'elidedbutton.cpp',
+  'screenview.h',
+  'screenview.cpp',
 ])
 
 executable('hyprland-share-picker',

--- a/hyprland-share-picker/screenview.cpp
+++ b/hyprland-share-picker/screenview.cpp
@@ -1,0 +1,88 @@
+#include <QScreen>
+#include <QResizeEvent>
+#include <algorithm>
+#include <iostream>
+
+#include "screenview.h"
+#include "elidedbutton.h"
+
+void ScreenView::activate(QApplication* app, QCheckBox* allowToken, QSettings* settings, MainPicker* mainPicker) {
+    const auto screens = app->screens();
+
+    int        lMost, rMost, tMost, bMost;
+    for (int i = 0; i < screens.size(); ++i) {
+        const auto geometry = screens[i]->geometry();
+
+        if (i) {
+            lMost = std::min(lMost, geometry.x());
+            tMost = std::min(tMost, geometry.y());
+            rMost = std::max(rMost, geometry.x() + geometry.width());
+            bMost = std::max(bMost, geometry.y() + geometry.height());
+        } else {
+            lMost = geometry.x();
+            tMost = geometry.y();
+            rMost = geometry.x() + geometry.width();
+            bMost = geometry.y() + geometry.height();
+        }
+    }
+
+    leftMost   = (double)lMost;
+    rightMost  = (double)rMost;
+    topMost    = (double)tMost;
+    bottomMost = (double)bMost;
+
+    for (int i = 0; i < screens.size(); ++i) {
+        const auto geometry = screens[i]->geometry();
+
+        QString    outputName = screens[i]->name();
+        QString    text =
+            QString::fromStdString(std::string("Screen " + std::to_string(i) + " (" + std::to_string(geometry.width()) + "x" + std::to_string(geometry.height()) + ") (") +
+                                   outputName.toStdString() + ")");
+
+        ElidedButton* button = new ElidedButton(text, this);
+
+        QObject::connect(button, &QPushButton::clicked, [=]() {
+            std::cout << "[SELECTION]";
+            std::cout << (allowToken->isChecked() ? "r" : "");
+            std::cout << "/";
+
+            std::cout << "screen:" << outputName.toStdString() << "\n";
+
+            settings->setValue("width", mainPicker->width());
+            settings->setValue("height", mainPicker->height());
+            settings->sync();
+
+            app->quit();
+            return 0;
+        });
+
+        buttons.append(button);
+        displays.append(geometry);
+    }
+}
+
+void ScreenView::resizeEvent(QResizeEvent* event) {
+    const double  newWidth  = (double)event->size().width();
+    const double  newHeight = (double)event->size().height();
+
+    const double  msWidth  = rightMost - leftMost;
+    const double  msHeight = bottomMost - topMost;
+
+    const double  fact = std::min(newWidth / msWidth, newHeight / msHeight);
+
+    const double  offset_x = (newWidth - msWidth * fact) / 2;
+    const double  offset_y = (newHeight - msHeight * fact) / 2;
+
+    constexpr int inset = 2;
+
+    for (int i = 0; i < buttons.size(); i++) {
+        QRect     screen = displays[i];
+
+        const int widgetX      = (int)(fact * (screen.x() - leftMost) + offset_x) + inset;
+        const int widgetY      = (int)(fact * (screen.y() - topMost) + offset_y) + inset;
+        const int widgetWidth  = (int)(fact * screen.width()) - 2 * inset;
+        const int widgetHeight = (int)(fact * screen.height()) - 2 * inset;
+
+        buttons[i]->setGeometry(widgetX, widgetY, widgetWidth, widgetHeight);
+    }
+}

--- a/hyprland-share-picker/screenview.h
+++ b/hyprland-share-picker/screenview.h
@@ -1,0 +1,31 @@
+#ifndef SCREENVIEW_H
+#define SCREENVIEW_H
+
+#include <QWidget>
+#include <QRect>
+#include <QApplication>
+#include <QCheckBox>
+#include <QSettings>
+
+#include "mainpicker.h"
+
+class ScreenView : public QWidget {
+  private:
+    QList<QWidget*> buttons;
+    QList<QRect>    displays;
+
+    double          leftMost;
+    double          rightMost;
+    double          topMost;
+    double          bottomMost;
+
+  public:
+    explicit ScreenView(QWidget* parent = nullptr) : QWidget(parent) {}
+
+    void activate(QApplication* app, QCheckBox* allowToken, QSettings* settings, MainPicker* mainPicker);
+
+  protected:
+    void resizeEvent(QResizeEvent* event) override;
+};
+
+#endif // SCREENVIEW_H


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5b94bcd9-2a7d-4730-b200-5001d88ccd09)

Instead of listing the monitor in a list, this shows them with the size and placement they have in hyprland's coordinate system.

I've marked this `[RFC]`, as I am not sure if this is in scope for this portal.