### PR TITLE
shared: include vector header

### DIFF
--- a/src/shared/ToplevelMappingManager.cpp
+++ b/src/shared/ToplevelMappingManager.cpp
@@ -1,5 +1,6 @@
 #include "ToplevelMappingManager.hpp"
 #include "../helpers/Log.hpp"
+#include <vector>
 
 CToplevelMappingManager::CToplevelMappingManager(SP<CCHyprlandToplevelMappingManagerV1> mgr) : m_pManager(mgr) {
     Debug::log(LOG, "[toplevel mapping] registered manager");


### PR DESCRIPTION
Fixes #334 (`no matching function for call to 'erase_if'`) on llvm/musl