### PR TITLE
nix: add meta.mainProgram to xdg-desktop-portal-hyprland

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
+    mainProgram = "xdg-desktop-portal-hyprland";
     homepage = "https://github.com/hyprwm/xdg-desktop-portal-hyprland";
     description = "xdg-desktop-portal backend for Hyprland";
     license = licenses.bsd3;


### PR DESCRIPTION
This change adds the meta.mainProgram attribute to the xdg-desktop-portal-hyprland package. This makes ${lib.getExe pkgs.xdg-desktop-portal-hyprland} work better (in my case in [the permissions list](https://github.com/luisnquin/nixos-config/commit/51c9037ffd23aa01b986f26f9586ceea0d3821bf)).

Without this attribute, using:
  `"${pkgs.xdg-desktop-portal-hyprland}/bin/xdg-desktop-portal-hyprland, screencopy, allow"`
is necessary, but I prefer the following 'cause is less verbose and is consistent with other programs I reference there:
  `"${lib.getExe pkgs.xdg-desktop-portal-hyprland}, screencopy, allow"`
