### PR TITLE
screencopy: add option to override default cursor_mode

### DIFF
--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -76,6 +76,7 @@ CPortalManager::CPortalManager() {
     m_sConfig.config->addConfigValue("screencopy:allow_token_by_default", Hyprlang::INT{0L});
     m_sConfig.config->addConfigValue("screencopy:custom_picker_binary", Hyprlang::STRING{""});
     m_sConfig.config->addConfigValue("screencopy:force_shm", Hyprlang::INT{0L});
+    m_sConfig.config->addConfigValue("screencopy:cursor_mode", Hyprlang::INT{0L});
 
     m_sConfig.config->commence();
     m_sConfig.config->parse();

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -76,12 +76,18 @@ dbUasv CScreencopyPortal::onSelectSources(sdbus::ObjectPath requestHandle, sdbus
     Debug::log(LOG, "[screencopy]  | {}", sessionHandle.c_str());
     Debug::log(LOG, "[screencopy]  | appid: {}", appID);
 
-    const auto PSESSION = getSession(sessionHandle);
+    const auto          PSESSION    = getSession(sessionHandle);
+    static auto* const* PCURSORMODE = (Hyprlang::INT* const*)g_pPortalManager->m_sConfig.config->getConfigValuePtr("screencopy:cursor_mode")->getDataStaticPtr();
 
     if (!PSESSION) {
         Debug::log(ERR, "[screencopy] SelectSources: no session found??");
         throw sdbus::Error{sdbus::Error::Name{"NOSESSION"}, "No session found"};
         return {1, {}};
+    }
+
+    if (**PCURSORMODE == HIDDEN || **PCURSORMODE == EMBEDDED) {
+        PSESSION->cursorMode = **PCURSORMODE;
+        Debug::log(LOG, "[screencopy] default cursor_mode to {}", PSESSION->cursorMode);
     }
 
     struct {
@@ -102,8 +108,14 @@ dbUasv CScreencopyPortal::onSelectSources(sdbus::ObjectPath requestHandle, sdbus
     for (auto& [key, val] : options) {
 
         if (key == "cursor_mode") {
-            PSESSION->cursorMode = val.get<uint32_t>();
-            Debug::log(LOG, "[screencopy] option cursor_mode to {}", PSESSION->cursorMode);
+            auto mode = val.get<uint32_t>();
+            if (mode == METADATA) {
+                // the portal spec actually says to kill the session here, but what's the point
+                Debug::log(LOG, "[screencopy] unsupported cursor_mode {}, fallback to {}", mode, PSESSION->cursorMode);
+            } else {
+                PSESSION->cursorMode = mode;
+                Debug::log(LOG, "[screencopy] option cursor_mode to {}", PSESSION->cursorMode);
+            }
         } else if (key == "restore_data") {
             // suv
             // v -> r(susbt) -> v2
@@ -173,7 +185,6 @@ dbUasv CScreencopyPortal::onSelectSources(sdbus::ObjectPath requestHandle, sdbus
                 Debug::log(LOG, "[screencopy] Restore token v3 {} with data: {} {} {} {} {}", restoreData.token, restoreData.windowHandle, restoreData.windowClass,
                            restoreData.output, restoreData.withCursor, restoreData.timeIssued);
             }
-
         } else if (key == "persist_mode") {
             PSESSION->persistMode = val.get<uint32_t>();
             Debug::log(LOG, "[screencopy] option persist_mode to {}", PSESSION->persistMode);


### PR DESCRIPTION
My previous pr fixed the cursor handling according to spec, but apparently hiding cursor according to spec is undesirable, since the only client known to properly ask for cursor is OBS. This adds a config variable to override the default cursor mode, if client doesn't specify.

xdph.conf:
`screencopy:cursor_mode = 2` to default to embedded and restore cursor in browsers/discord

Tested:
- OBS checkbox still overrides our default setting like supposed to
- Mozilla gUM Test Page in firefox and chromium don't ask for any cursor mode, but new setting works fine

fixes #378