### PR TITLE
screencopy: add DMA-BUF to SHM fallback

### DIFF
--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -44,6 +44,7 @@ CPortalManager::CPortalManager() {
     m_sConfig.config->addConfigValue("screencopy:max_fps", Hyprlang::INT{120L});
     m_sConfig.config->addConfigValue("screencopy:allow_token_by_default", Hyprlang::INT{0L});
     m_sConfig.config->addConfigValue("screencopy:custom_picker_binary", Hyprlang::STRING{""});
+    m_sConfig.config->addConfigValue("screencopy:force_shm", Hyprlang::INT{0L});
 
     m_sConfig.config->commence();
     m_sConfig.config->parse();

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -8,7 +8,8 @@
 #include "linux-dmabuf-v1.hpp"
 #include <unistd.h>
 
-constexpr static int MAX_RETRIES = 10;
+constexpr static int MAX_RETRIES        = 10;
+constexpr static int MAX_DMABUF_RETRIES = 2;
 
 //
 static sdbus::Struct<std::string, uint32_t, sdbus::Variant> getFullRestoreStruct(const SSelectionData& data, uint32_t cursor) {
@@ -749,6 +750,17 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param) 
 
         if ((prop_modifier->flags & SPA_POD_PROP_FLAG_DONT_FIXATE) > 0) {
             Debug::log(TRACE, "[pw] don't fixate");
+
+            if (++PSTREAM->dmaBufRetries > MAX_DMABUF_RETRIES) {
+                Debug::log(ERR, "[pw] DMA-BUF fixation failed after {} attempts, falling back to SHM", PSTREAM->dmaBufRetries - 1);
+                PSTREAM->dmaBufFailed = true;
+                g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
+                spa_pod_dynamic_builder_clean(&dynBuilder[0]);
+                spa_pod_dynamic_builder_clean(&dynBuilder[1]);
+                spa_pod_dynamic_builder_clean(&dynBuilder[2]);
+                return;
+            }
+
             const spa_pod* pod_modifier = &prop_modifier->value;
 
             uint32_t       n_modifiers = SPA_POD_CHOICE_N_VALUES(pod_modifier) - 1;
@@ -788,6 +800,11 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param) 
             }
 
             Debug::log(ERR, "[pw] failed to alloc dma");
+            PSTREAM->dmaBufFailed = true;
+            g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
+            spa_pod_dynamic_builder_clean(&dynBuilder[0]);
+            spa_pod_dynamic_builder_clean(&dynBuilder[1]);
+            spa_pod_dynamic_builder_clean(&dynBuilder[2]);
             return;
 
         fixate_format:
@@ -1038,11 +1055,14 @@ static bool build_modifierlist(CPipewireConnection::SPWStream* stream, uint32_t 
 }
 
 uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_pod* params[2], CPipewireConnection::SPWStream* stream) {
-    uint32_t  paramCount = 0;
-    uint32_t  modCount   = 0;
-    uint64_t* modifiers  = nullptr;
+    uint32_t            paramCount = 0;
+    uint32_t            modCount   = 0;
+    uint64_t*           modifiers  = nullptr;
 
-    if (build_modifierlist(stream, stream->pSession->sharingData.frameInfoDMA.fmt, &modifiers, &modCount) && modCount > 0) {
+    static auto* const* PFORCESHM = (Hyprlang::INT* const*)g_pPortalManager->m_sConfig.config->getConfigValuePtr("screencopy:force_shm")->getDataStaticPtr();
+    const bool          forceSHM  = **PFORCESHM || stream->dmaBufFailed;
+
+    if (!forceSHM && build_modifierlist(stream, stream->pSession->sharingData.frameInfoDMA.fmt, &modifiers, &modCount) && modCount > 0) {
         Debug::log(LOG, "[pw] Building modifiers for dma");
 
         paramCount = 2;
@@ -1053,7 +1073,12 @@ uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_p
                                  stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
         assert(params[1] != NULL);
     } else {
-        Debug::log(LOG, "[pw] Building modifiers for shm");
+        if (stream->dmaBufFailed)
+            Debug::log(WARN, "[pw] DMA-BUF allocation failed, falling back to SHM");
+        else if (forceSHM)
+            Debug::log(LOG, "[pw] DMA-BUF disabled (force_shm), using SHM only");
+        else
+            Debug::log(LOG, "[pw] Building modifiers for shm");
 
         paramCount = 1;
         params[0]  = build_format(b[0], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoSHM.fmt), stream->pSession->sharingData.frameInfoSHM.w,

--- a/src/portals/Screencopy.hpp
+++ b/src/portals/Screencopy.hpp
@@ -2,6 +2,7 @@
 
 #include "wlr-screencopy-unstable-v1.hpp"
 #include "hyprland-toplevel-export-v1.hpp"
+#include <cstdint>
 #include <hyprutils/memory/UniquePtr.hpp>
 #include <hyprutils/memory/WeakPtr.hpp>
 #include <sdbus-c++/sdbus-c++.h>
@@ -154,8 +155,10 @@ class CPipewireConnection {
         spa_hook                              streamListener;
         SBuffer*                              currentPWBuffer = nullptr;
         spa_video_info_raw                    pwVideoInfo;
-        uint32_t                              seq   = 0;
-        bool                                  isDMA = false;
+        uint32_t                              seq           = 0;
+        bool                                  isDMA         = false;
+        uint32_t                              dmaBufRetries = 0;
+        bool                                  dmaBufFailed  = false;
 
         std::vector<std::unique_ptr<SBuffer>> buffers;
     };


### PR DESCRIPTION
Closes #361, closes #325

## Problem
On multi-GPU systems where an Intel iGPU is the primary render device, screensharing enters an infinite DMA-BUF negotiation loop. The log shows hundreds of repeated lines:

```
[pw] Building modifiers for dma
[pw] unable to allocate a dmabuf with modifiers. Falling back to the old api
[pw] Format fixated: ... modifier: 0
```

Root cause: `gbm_bo_create_with_modifiers2()` fails, the fallback `gbm_bo_create()` succeeds as a probe, XDPH fixates on modifier 0, PipeWire accepts but actual buffer allocation fails, PipeWire renegotiates → infinite loop.

A second loop variant exists when both `gbm_bo_create` calls fail entirely: bare `return` without `updateStreamParam()` causes PipeWire to retry indefinitely. This also leaks the `spa_pod_dynamic_builder`.

## Fix
- Track `dmaBufRetries` per stream; after `MAX_DMABUF_RETRIES` failures   fall back to SHM
- Handle total `gbm_bo_create` failure: set `dmaBufFailed`, call   `updateStreamParam()`, clean up dynamic builders
- Add `screencopy:force_shm` config option to skip DMA-BUF entirely

## Test plan
**To reproduce on master:**
1. Multi-GPU system with Intel as primary
2. Start Hyprland, open a browser
3. Trigger screenshare (e.g. Google Meet, Discord, or https://mozilla.github.io/webrtc-landing/gum_test.html)
4. Observe: share dialog appears but stream never starts
5. Log shows the "Building modifiers for dma" loop

**To verify the fix:**
1. Build and install the patched binary
2. Trigger screenshare
3. Log shows: `DMA-BUF fixation failed after 2 attempts, falling back to SHM`
4. Screensharing works
5. No errors in log after stopping the share

**To test force_shm:**
1. Add `force_shm = 1` in the `screencopy` section of `~/.config/hypr/xdph.conf`
2. Restart the portal, trigger screenshare
3. Log shows: `DMA-BUF disabled (force_shm), using SHM only`
4. No DMA-BUF attempts at all, immediate SHM

**Note:** The same infinite loop also affects `wl-screenrecorder` and other tools sharing the same PipeWire negotiation pattern.

## System
- Manjaro, Kernel 6.18, Hyprland 0.53.3, PipeWire 1.4.10
- Intel TigerLake UHD (primary) + NVIDIA RTX A2000 (secondary)
- 3840×2160@60Hz