### PR TITLE
screencopy: save and restore geometry for region sharing

### DIFF
--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -17,6 +17,9 @@ static sdbus::Struct<std::string, uint32_t, sdbus::Variant> getFullRestoreStruct
 
     switch (data.type) {
         case TYPE_GEOMETRY:
+            mapData["output"]   = sdbus::Variant{data.output};
+            mapData["geometry"] = sdbus::Variant{sdbus::Struct<uint32_t, uint32_t, uint32_t, uint32_t>{data.x, data.y, data.w, data.h}};
+            break;
         case TYPE_OUTPUT: mapData["output"] = sdbus::Variant{data.output}; break;
         case TYPE_WINDOW:
             mapData["windowHandle"] = sdbus::Variant{(uint64_t)data.windowHandle->resource()};
@@ -86,6 +89,12 @@ dbUasv CScreencopyPortal::onSelectSources(sdbus::ObjectPath requestHandle, sdbus
         bool        withCursor;
         uint64_t    timeIssued;
         std::string windowClass;
+        struct {
+            uint32_t x = 0;
+            uint32_t y = 0;
+            uint32_t w = 0;
+            uint32_t h = 0;
+        } geometry;
     } restoreData;
 
     for (auto& [key, val] : options) {
@@ -149,7 +158,13 @@ dbUasv CScreencopyPortal::onSelectSources(sdbus::ObjectPath requestHandle, sdbus
                         restoreData.timeIssued = tkval.get<uint64_t>();
                     else if (tkkey == "token")
                         restoreData.token = tkval.get<std::string>();
-                    else
+                    else if (tkkey == "geometry") {
+                        auto geo               = tkval.get<sdbus::Struct<uint32_t, uint32_t, uint32_t, uint32_t>>();
+                        restoreData.geometry.x = geo.get<0>();
+                        restoreData.geometry.y = geo.get<1>();
+                        restoreData.geometry.w = geo.get<2>();
+                        restoreData.geometry.h = geo.get<3>();
+                    } else
                         Debug::log(LOG, "[screencopy] restore token v3, unknown prop {}", tkkey);
                 }
 
@@ -178,14 +193,22 @@ dbUasv CScreencopyPortal::onSelectSources(sdbus::ObjectPath requestHandle, sdbus
         Debug::log(LOG, "[screencopy] restore data valid, not prompting");
 
         const bool WINDOW      = !restoreData.windowClass.empty();
+        const bool GEOMETRY    = restoreData.geometry.w > 0 && restoreData.geometry.h > 0;
         const auto HANDLEMATCH = WINDOW && restoreData.windowHandle != 0 ? g_pPortalManager->m_sHelpers.toplevel->handleFromHandleFull(restoreData.windowHandle) : nullptr;
 
         SHAREDATA.output       = restoreData.output;
-        SHAREDATA.type         = WINDOW ? TYPE_WINDOW : TYPE_OUTPUT;
+        SHAREDATA.type         = WINDOW ? TYPE_WINDOW : (GEOMETRY ? TYPE_GEOMETRY : TYPE_OUTPUT);
         SHAREDATA.windowHandle = WINDOW ? (HANDLEMATCH ? HANDLEMATCH->handle : g_pPortalManager->m_sHelpers.toplevel->handleFromClass(restoreData.windowClass)->handle) : nullptr;
         SHAREDATA.windowClass  = restoreData.windowClass;
         SHAREDATA.allowToken   = true; // user allowed token before
         PSESSION->cursorMode   = restoreData.withCursor ? EMBEDDED : HIDDEN;
+
+        if (GEOMETRY) {
+            SHAREDATA.x = restoreData.geometry.x;
+            SHAREDATA.y = restoreData.geometry.y;
+            SHAREDATA.w = restoreData.geometry.w;
+            SHAREDATA.h = restoreData.geometry.h;
+        }
     } else {
         Debug::log(LOG, "[screencopy] restore data invalid / missing, prompting");
 


### PR DESCRIPTION
TYPE_GEOMETRY was falling through to TYPE_OUTPUT when saving the restore token, losing the geometry data. When restoring, the type was always set to TYPE_OUTPUT since geometry wasn't parsed.

This adds proper geometry serialization in the token and restores the region selection correctly.

Related: #44 

Additional info: 

- I usually do not develop desktop apps / linux / cpp, I might not have done this the correct way.
- To my understanding adding the geometry key, will still be backwards compatible so no requirement for a new message version
- I was unable to compile without adding hyprutils as dependency and XDPH_VERRSION as a project argument, is this project supposed to be compiled together with hyprutils?
- This might be a workaround for the underlying issue, but whenever chrome(ium) tries to share a screen, it seems to do a preview  the share, and when you press OK, it restores from token. I'm unsure if this is intended, or if something else is going wrong, but with this fix, I was finally able to share regions. Journal below.

```
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pipewire] Asked for a wl_shm buffer which is legacy.
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pipewire] Asked for a wl_shm buffer which is legacy.
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [ERR] [screencopy] tried scheduling on already scheduled cb (type 2)
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Stream destroyed
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Session destroyed
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [toplevel] (deactivate) locks: 1
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [toplevel] (activate) locks: 2
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] New session:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/request/1_57/webrtc_1078735493
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/session/1_57/webrtc_session126403468
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | appid: org.chromium.Chromium
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] SelectSources:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/request/1_57/webrtc234073696
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/session/1_57/webrtc_session126403468
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | appid: org.chromium.Chromium
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] option persist_mode to 1
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] unused option multiple
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] unused option types
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] restore data invalid / missing, prompting
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [sc] Selection: r/region:DP-4@2312,748,50,18
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] SHAREDATA returned selection 2
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Start:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/request/1_57/webrtc1495986525
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/session/1_57/webrtc_session126403468
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | appid: org.chromium.Chromium
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | parent_window:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [pw] Building modifiers for dma
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Sharing initialized
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Sent restore token to /org/freedesktop/portal/desktop/session/1_57/webrtc_session126403468
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [pw] Building modifiers for dma
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [pw] Building modifiers for dma
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [ERR] [screencopy] tried scheduling on already scheduled cb (type 2)
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [ERR] [pw] DMA-BUF fixation failed after 2 attempts, falling back to SHM
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pw] DMA-BUF allocation failed, falling back to SHM
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pipewire] Asked for a wl_shm buffer which is legacy.
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pipewire] Asked for a wl_shm buffer which is legacy.
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pipewire] Asked for a wl_shm buffer which is legacy.
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pipewire] Asked for a wl_shm buffer which is legacy.
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [ERR] [screencopy] tried scheduling on already scheduled cb (type 2)
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Stream destroyed
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Session destroyed
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [toplevel] (deactivate) locks: 1
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [toplevel] (activate) locks: 2
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] New session:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/request/1_57/webrtc_520027355
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/session/1_57/webrtc_session319822128
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | appid: org.chromium.Chromium
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] SelectSources:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/request/1_57/webrtc78987352
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/session/1_57/webrtc_session319822128
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | appid: org.chromium.Chromium
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Restore token from hyprland ver 3
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Restore token v3 todo with data: 93962499847232  DP-4 false 1773219476
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] option persist_mode to 1
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] unused option multiple
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] unused option types
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] restore data valid, not prompting
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] SHAREDATA returned selection 2
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Start:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/request/1_57/webrtc11505226
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | /org/freedesktop/portal/desktop/session/1_57/webrtc_session319822128
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | appid: org.chromium.Chromium
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy]  | parent_window:
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [pw] Building modifiers for dma
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Sharing initialized
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [screencopy] Sent restore token to /org/freedesktop/portal/desktop/session/1_57/webrtc_session319822128
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [pw] Building modifiers for dma
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [LOG] [pw] Building modifiers for dma
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [ERR] [screencopy] tried scheduling on already scheduled cb (type 2)
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [ERR] [pw] DMA-BUF fixation failed after 2 attempts, falling back to SHM
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pw] DMA-BUF allocation failed, falling back to SHM
Mar 11 09:57:58 desktop xdg-desktop-portal-hyprland[63963]: [WARN] [pipewire] Asked for a wl_shm buffer which is legacy.
```