### PR TITLE
picker: add window icons when available

### DIFF
--- a/hyprland-share-picker/elidedbutton.cpp
+++ b/hyprland-share-picker/elidedbutton.cpp
@@ -17,6 +17,16 @@ void ElidedButton::setText(QString text)
     updateText();
 }
 
+void ElidedButton::setIcon(const QIcon& icon) {
+    QPushButton::setIcon(icon);
+    updateText();
+}
+
+void ElidedButton::setIconSize(const QSize& size) {
+    QPushButton::setIconSize(size);
+    updateText();
+}
+
 void ElidedButton::resizeEvent(QResizeEvent *event)
 {
     QPushButton::resizeEvent(event);
@@ -26,6 +36,9 @@ void ElidedButton::resizeEvent(QResizeEvent *event)
 void ElidedButton::updateText()
 {
     QFontMetrics metrics(font());
-    QString elided = metrics.elidedText(og_text, Qt::ElideRight, width() - 15);
+    int          availableWidth = width() - 15;
+    if (!icon().isNull())
+        availableWidth -= iconSize().width() + 5;
+    QString elided = metrics.elidedText(og_text, Qt::ElideRight, availableWidth);
     QPushButton::setText(elided);
 }

--- a/hyprland-share-picker/elidedbutton.cpp
+++ b/hyprland-share-picker/elidedbutton.cpp
@@ -22,11 +22,6 @@ void ElidedButton::setIcon(const QIcon& icon) {
     updateText();
 }
 
-void ElidedButton::setIconSize(const QSize& size) {
-    QPushButton::setIconSize(size);
-    updateText();
-}
-
 void ElidedButton::resizeEvent(QResizeEvent *event)
 {
     QPushButton::resizeEvent(event);

--- a/hyprland-share-picker/elidedbutton.h
+++ b/hyprland-share-picker/elidedbutton.h
@@ -12,7 +12,6 @@ public:
     explicit ElidedButton(const QString &text, QWidget *parent = nullptr);
     void setText(QString);
     void setIcon(const QIcon &icon);
-    void setIconSize(const QSize &size);
 
 protected:
     void resizeEvent(QResizeEvent *);

--- a/hyprland-share-picker/elidedbutton.h
+++ b/hyprland-share-picker/elidedbutton.h
@@ -2,6 +2,8 @@
 #define ELIDEDBUTTON_H
 
 #include <QPushButton>
+#include <QIcon>
+#include <QSize>
 
 class ElidedButton : public QPushButton
 {
@@ -9,6 +11,8 @@ public:
     explicit ElidedButton(QWidget *parent = nullptr);
     explicit ElidedButton(const QString &text, QWidget *parent = nullptr);
     void setText(QString);
+    void setIcon(const QIcon &icon);
+    void setIconSize(const QSize &size);
 
 protected:
     void resizeEvent(QResizeEvent *);

--- a/hyprland-share-picker/main.cpp
+++ b/hyprland-share-picker/main.cpp
@@ -163,7 +163,6 @@ int main(int argc, char* argv[]) {
 
         ElidedButton* button = new ElidedButton(text);
         button->setIcon(QIcon::fromTheme(QString::fromStdString(window.clazz)));
-        button->setIconSize(QSize(BUTTON_HEIGHT - 9, BUTTON_HEIGHT - 9));
         button->setMinimumSize(0, BUTTON_HEIGHT);
         WINDOWS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);
 

--- a/hyprland-share-picker/main.cpp
+++ b/hyprland-share-picker/main.cpp
@@ -162,7 +162,7 @@ int main(int argc, char* argv[]) {
         QString       text = QString::fromStdString(window.clazz + ": " + window.name);
 
         ElidedButton* button = new ElidedButton(text);
-        button->setIcon(QIcon::fromTheme(QString::fromStdString(window.clazz), QIcon::fromTheme("application-x-executable")));
+        button->setIcon(QIcon::fromTheme(QString::fromStdString(window.clazz)));
         button->setIconSize(QSize(BUTTON_HEIGHT - 9, BUTTON_HEIGHT - 9));
         button->setMinimumSize(0, BUTTON_HEIGHT);
         WINDOWS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);

--- a/hyprland-share-picker/main.cpp
+++ b/hyprland-share-picker/main.cpp
@@ -1,8 +1,10 @@
 #include <QApplication>
 #include <QEvent>
+#include <QIcon>
 #include <QObject>
 #include <QPushButton>
 #include <QScreen>
+#include <QSize>
 #include <QTabWidget>
 #include <QWidget>
 #include <QtDebug>
@@ -63,7 +65,7 @@ std::vector<SWindowEntry> getWindows(const char* env) {
 
         // window address
         const auto WINDOWSEPPOS = rolling.find("[HA>]");
-        const auto WINDOWADDR = rolling.substr(TITLESEPPOS + 5, WINDOWSEPPOS - 5 - TITLESEPPOS);
+        const auto WINDOWADDR   = rolling.substr(TITLESEPPOS + 5, WINDOWSEPPOS - 5 - TITLESEPPOS);
 
         try {
             result.push_back({TITLESTR, CLASSSTR, std::stoull(IDSTR)});
@@ -160,6 +162,8 @@ int main(int argc, char* argv[]) {
         QString       text = QString::fromStdString(window.clazz + ": " + window.name);
 
         ElidedButton* button = new ElidedButton(text);
+        button->setIcon(QIcon::fromTheme(QString::fromStdString(window.clazz), QIcon::fromTheme("application-x-executable")));
+        button->setIconSize(QSize(BUTTON_HEIGHT - 9, BUTTON_HEIGHT - 9));
         button->setMinimumSize(0, BUTTON_HEIGHT);
         WINDOWS_SCROLL_AREA_CONTENTS_LAYOUT->addWidget(button);
 


### PR DESCRIPTION
Adds icons when picking a window, based on the window class (if the icon is available). I just think it helps to pick a window faster.

**AI disclosure:** Used gemini-cli to write the first commit, because I'm inexperienced w/ Qt. this PR text is handwritten.

## Preview:

this is pretty much the full extent to which i tested this - just tried on my system which already has a Qt theme and icons setup, ensuring that i had one window w/o an icon (gamescope) to make sure those buttons display as before.

<details>
<summary>(old preview)</summary>

<img width="750" height="435" alt="image" src="https://github.com/user-attachments/assets/57750275-0b3f-44e0-9616-646c93b079c6" />

</details>

edit: omitting setIconSize since Qt seems to have a sensible icon size already:

<img width="750" height="435" alt="image" src="https://github.com/user-attachments/assets/8853fc3f-e8ae-498a-a474-7b32aca47fca" />
