### PR TITLE
portals: Add missing buffer data flags SPA_DATA_FLAG_READABLE and SPA_DATA_FLAG_MAPPABLE.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,11 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
+[*.{c,cpp,h,hpp}]
+indent_style = space
+indent_size = 4
+tab_width = 4
+
 [*.{xml,yml}]
 indent_style = space
 indent_size = 2

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -887,9 +887,13 @@ static void pwStreamAddBuffer(void* data, pw_buffer* buffer) {
 
     spa_data*     spaData = buffer->buffer->datas;
     spa_data_type type;
+    uint32_t      flags = SPA_DATA_FLAG_READABLE;
 
     if ((spaData[0].type & (1u << SPA_DATA_MemFd)) > 0) {
         type = SPA_DATA_MemFd;
+#ifdef SPA_DATA_FLAG_MAPPABLE
+        flags = flags | SPA_DATA_FLAG_MAPPABLE;
+#endif
         Debug::log(WARN, "[pipewire] Asked for a wl_shm buffer which is legacy.");
     } else if ((spaData[0].type & (1u << SPA_DATA_DmaBuf)) > 0) {
         type = SPA_DATA_DmaBuf;
@@ -912,7 +916,7 @@ static void pwStreamAddBuffer(void* data, pw_buffer* buffer) {
         spaData[plane].chunk->size   = PBUFFER->size[plane];
         spaData[plane].chunk->stride = PBUFFER->stride[plane];
         spaData[plane].chunk->offset = PBUFFER->offset[plane];
-        spaData[plane].flags         = 0;
+        spaData[plane].flags         = flags;
         spaData[plane].fd            = PBUFFER->fd[plane];
         spaData[plane].data          = NULL;
         // clients have implemented to check chunk->size if the buffer is valid instead


### PR DESCRIPTION
This fix is for issue https://github.com/hyprwm/xdg-desktop-portal-hyprland/issues/388

The code is basically copied from [pipewire_screencast.c in xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr/blob/master/src/screencast/pipewire_screencast.c).

Also the .editorconfig should be updated for correct indentation in cpp files, otherwise the editor will use tabs instead of 4 spaces for indents.

