### PR TITLE
fix: SToplevelHandle accesses member after freeing itself

### DIFF
--- a/src/shared/ToplevelManager.cpp
+++ b/src/shared/ToplevelManager.cpp
@@ -18,9 +18,10 @@ SToplevelHandle::SToplevelHandle(SP<CCZwlrForeignToplevelHandleV1> handle_) : ha
     handle->setClosed([this](CCZwlrForeignToplevelHandleV1* r) {
         Debug::log(TRACE, "[toplevel] toplevel at {} closed", (void*)this);
 
-        std::erase_if(g_pPortalManager->m_sHelpers.toplevel->m_vToplevels, [&](const auto& e) { return e.get() == this; });
         if (g_pPortalManager->m_sHelpers.toplevelMapping)
             g_pPortalManager->m_sHelpers.toplevelMapping->m_muAddresses.erase(this->handle);
+        // frees `this`
+        std::erase_if(g_pPortalManager->m_sHelpers.toplevel->m_vToplevels, [&](const auto& e) { return e.get() == this; });
     });
 }
 


### PR DESCRIPTION
The `SToplevelHandle`s are only stored in m_vToplevels, so once it's erased from there, `this` is invalid and already freed. Reordering the code to free `this` last should be a good fix.

Technically I think doing further pointer equality checks might not be super sound but in this context I'm pretty sure it's fine in practice.