### PR TITLE
globalshortcuts: race-safe session lifetimes

### DIFF
--- a/src/shared/Session.cpp
+++ b/src/shared/Session.cpp
@@ -20,8 +20,12 @@ static int onCloseSession(SDBusSession* sess) {
     if (!sess)
         return 0;
 
-    sess->onDestroy();
-    sess->object.release();
+    auto destroy = std::move(sess->onDestroy);
+    g_pPortalManager->addTimer({0, [sess, destroy]() {
+        sess->object.reset();
+        if (destroy)
+            destroy();
+    }});
 
     return 0;
 }


### PR DESCRIPTION
fixes: hyprwm/xdg-desktop-portal-hyprland#394

Existing release of session handle leaves an opportunity open for a race condition with an immediate request to reopen a session with the same session handle token.  The chromium implementation of global shortcuts exposes this opportunity.  This code resets the handle so the creation of a new session will not reveal an existing closed handle.  This cannot be done directly in onCloseSession so the action is deferred.

This release pattern exists elsewhere, but this PR is focused on the session destroy/create race.