### PR TITLE
screencast: bump backend to v6 (version property + mapping_id + pipewire-serial)

### DIFF
--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -3,6 +3,8 @@
 #include "../helpers/Log.hpp"
 #include "../helpers/MiscFunctions.hpp"
 
+#include <cerrno>
+#include <cstdlib>
 #include <libdrm/drm_fourcc.h>
 #include <pipewire/pipewire.h>
 #include "linux-dmabuf-v1.hpp"
@@ -282,6 +284,13 @@ dbUasv CScreencopyPortal::onStart(sdbus::ObjectPath requestHandle, sdbus::Object
     streamData["position"]    = sdbus::Variant{sdbus::Struct<int32_t, int32_t>{0, 0}};
     streamData["size"]        = sdbus::Variant{sdbus::Struct<int32_t, int32_t>{PSESSION->sharingData.frameInfoSHM.w, PSESSION->sharingData.frameInfoSHM.h}};
     streamData["source_type"] = sdbus::Variant{uint32_t{type}};
+
+    if (PSESSION->selection.type == TYPE_OUTPUT && !PSESSION->selection.output.empty())
+        streamData["mapping_id"] = sdbus::Variant{PSESSION->selection.output};
+
+    if (PSESSION->sharingData.pipewireSerial != 0)
+        streamData["pipewire-serial"] = sdbus::Variant{PSESSION->sharingData.pipewireSerial};
+
     streams.emplace_back(sdbus::Struct<uint32_t, std::unordered_map<std::string, sdbus::Variant>>{PSESSION->sharingData.nodeID, streamData});
 
     options["streams"] = sdbus::Variant{streams};
@@ -650,7 +659,7 @@ CScreencopyPortal::CScreencopyPortal(SP<CCZwlrScreencopyManagerV1> mgr) {
                                                                         std::unordered_map<std::string, sdbus::Variant> m1) { return onStart(o1, o2, s1, s2, m1); }),
                     sdbus::registerProperty("AvailableSourceTypes").withGetter([]() { return uint32_t{VIRTUAL | MONITOR | WINDOW}; }),
                     sdbus::registerProperty("AvailableCursorModes").withGetter([]() { return uint32_t{HIDDEN | EMBEDDED}; }),
-                    sdbus::registerProperty("version").withGetter([]() { return uint32_t{3}; }))
+                    sdbus::registerProperty("version").withGetter([]() { return uint32_t{6}; }))
         .forInterface(INTERFACE_NAME);
 
     m_sState.screencopy = mgr;
@@ -708,13 +717,29 @@ CPipewireConnection::~CPipewireConnection() {
 
 // --------------- Pipewire Stream Handlers --------------- //
 
+static uint64_t readObjectSerial(pw_stream* stream) {
+    const pw_properties* props = pw_stream_get_properties(stream);
+    if (!props)
+        return 0;
+    const char* serial_str = pw_properties_get(props, PW_KEY_OBJECT_SERIAL);
+    if (!serial_str)
+        return 0;
+    char*    end = nullptr;
+    errno        = 0;
+    uint64_t s   = std::strtoull(serial_str, &end, 10);
+    if (errno != 0 || end == serial_str)
+        return 0;
+    return s;
+}
+
 static void pwStreamStateChange(void* data, pw_stream_state old, pw_stream_state state, const char* error) {
     const auto PSTREAM = (CPipewireConnection::SPWStream*)data;
 
-    PSTREAM->pSession->sharingData.nodeID = pw_stream_get_node_id(PSTREAM->stream);
+    PSTREAM->pSession->sharingData.nodeID         = pw_stream_get_node_id(PSTREAM->stream);
+    PSTREAM->pSession->sharingData.pipewireSerial = readObjectSerial(PSTREAM->stream);
 
-    Debug::log(TRACE, "[pw] pwStreamStateChange on {} from {} to {}, node id {}", (void*)PSTREAM, pw_stream_state_as_string(old), pw_stream_state_as_string(state),
-               PSTREAM->pSession->sharingData.nodeID);
+    Debug::log(TRACE, "[pw] pwStreamStateChange on {} from {} to {}, node id {} serial {}", (void*)PSTREAM, pw_stream_state_as_string(old), pw_stream_state_as_string(state),
+               PSTREAM->pSession->sharingData.nodeID, PSTREAM->pSession->sharingData.pipewireSerial);
 
     switch (state) {
         case PW_STREAM_STATE_STREAMING:
@@ -999,9 +1024,10 @@ void CPipewireConnection::createStream(CScreencopyPortal::SSession* pSession) {
 
     pw_stream_connect(PSTREAM->stream, PW_DIRECTION_OUTPUT, PW_ID_ANY, (pw_stream_flags)(PW_STREAM_FLAG_DRIVER | PW_STREAM_FLAG_ALLOC_BUFFERS), params, PARAMCOUNT);
 
-    pSession->sharingData.nodeID = pw_stream_get_node_id(PSTREAM->stream);
+    pSession->sharingData.nodeID         = pw_stream_get_node_id(PSTREAM->stream);
+    pSession->sharingData.pipewireSerial = readObjectSerial(PSTREAM->stream);
 
-    Debug::log(TRACE, "[pw] Stream got nodeid {}", pSession->sharingData.nodeID);
+    Debug::log(TRACE, "[pw] Stream got nodeid {} serial {}", pSession->sharingData.nodeID, pSession->sharingData.pipewireSerial);
 }
 
 void CPipewireConnection::destroyStream(CScreencopyPortal::SSession* pSession) {

--- a/src/portals/Screencopy.hpp
+++ b/src/portals/Screencopy.hpp
@@ -87,6 +87,7 @@ class CScreencopyPortal {
             uint32_t                              tvNsec              = 0;
             uint64_t                              tvTimestampNs       = 0;
             uint32_t                              nodeID              = 0;
+            uint64_t                              pipewireSerial      = 0;
             uint32_t                              framerate           = 60;
             wl_output_transform                   transform           = WL_OUTPUT_TRANSFORM_NORMAL;
             std::chrono::system_clock::time_point begunFrame          = std::chrono::system_clock::now();


### PR DESCRIPTION
Closes #387.

Three changes that together advance the Screencopy portal backend from advertised version 3 to actual version 6.

## Why

PipeWire node IDs (uint32) are reused after stream destruction. Monitor hotplug, dock/undock, and similar reconfigure events tear down and recreate streams, and consumers holding the old node_id can silently bind to the wrong one. PipeWire fixed this on its side in 0.3.64 by introducing `object.serial` (uint64, monotonically increasing, never reused). The xdg-desktop-portal spec change exposing this through D-Bus just merged: flatpak/xdg-desktop-portal#1942.

`mapping_id` (v5) is the matching feature for multi-monitor input targeting: a stable identifier for the source the stream came from. For output streams it is the wlr_output name.

## What changed (~33 lines)

1. **Version property** (`Screencopy.cpp:653`): `uint32_t{3}` → `uint32_t{6}`. The backend already implements v4 restore tokens (lines 110-129) but the property never bumped. Bumping to 6 brings advertisement in line with implementation and adds the two new dict keys.

2. **`mapping_id`** (`Screencopy.cpp:onStart`): for `TYPE_OUTPUT` streams, populate from `selection.output` (the wlr_output name), already in `SSelectionData`.

3. **`pipewire-serial`** (`Screencopy.cpp` two pw_stream_get_node_id sites + `Screencopy.hpp` sharingData struct): a small static helper `readObjectSerial()` reads `PW_KEY_OBJECT_SERIAL` from the stream's properties and parses it as `uint64_t`. Called next to `pw_stream_get_node_id()` in both `pwStreamStateChange` and the end of `createStream`. Stored on `sharingData.pipewireSerial` and emitted in the stream dict.

## Version negotiation

The xdg-desktop-portal frontend (post flatpak/xdg-desktop-portal#1942) derives its advertised ScreenCast version as `MIN(backend_version, 6)`. Apps see v6 only when this backend is loaded and supplies `pipewire-serial` in the stream dict.

`pipewire-serial` is only emitted when extraction actually succeeds (non-zero), preserving the presence guarantee that v6 implies.

## Toplevel windows (mapping_id)

`mapping_id` for window streams is intentionally deferred. `hyprland-toplevel-mapping-v1` (#322) covers the consumer/compositor path directly without portal mediation, so the window case does not need a portal-side `mapping_id`. Output streams, where mapping_id is most needed, are covered here.

## Backward compatibility

Existing consumers that read only `node_id` from the stream tuple are unaffected. The new dict keys are additive.

## Testing

Diff is mechanical (struct field, version literal, two helper-call sites, two dict-append sites, no architectural change). Build verification deferred to project CI.

Refs: flatpak/xdg-desktop-portal#1942, flatpak/xdg-desktop-portal#979.