### PR TITLE
helpers: run hyprctl notify through argv instead of a shell

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -1,5 +1,4 @@
 #include "MiscFunctions.hpp"
-#include "../helpers/Log.hpp"
 
 #include <unistd.h>
 #include <filesystem>
@@ -7,6 +6,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <format>
 
 #include <hyprutils/os/Process.hpp>
 using namespace Hyprutils::OS;
@@ -22,10 +22,9 @@ std::string execAndGet(const char* cmd) {
 }
 
 void addHyprlandNotification(const std::string& icon, float timeMs, const std::string& color, const std::string& message) {
-    const std::string CMD = std::format("hyprctl notify {} {} {} \"{}\"", icon, timeMs, color, message);
-    Debug::log(LOG, "addHyprlandNotification: {}", CMD);
-    if (fork() == 0)
-        execl("/bin/sh", "/bin/sh", "-c", CMD.c_str(), nullptr);
+    // argv, never /bin/sh -c: `message` can carry untrusted text (e.g. an app_id) a shell would expand
+    CProcess proc("hyprctl", {"notify", icon, std::format("{}", timeMs), color, message});
+    proc.runAsync();
 }
 
 bool inShellPath(const std::string& exec) {


### PR DESCRIPTION
addHyprlandNotification fork()'d and ran /bin/sh -c with the message interpolated into the command. three issues, two of them live today: the child has no _exit guard, so a failed execl drops a forked clone back into the caller; nothing reaps it (xdph installs no SIGCHLD handler), so every notification leaks a zombie for the life of the process and interpolating the message would let metacharacters in untrusted text (e.g. a portal app_id) execute. run hyprctl through a CProcess argv vector instead: no shell parsing, each field one opaque argument, and the child is managed rather than orphaned. drop the now-dead Debug::log line and its Log.hpp include, and add <format> explicitly, since the file had only been getting it transitively through that header.