### PR TITLE
build: link hyprutils in the picker meson build and ignore meson wrap locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ result-man
 
 # MISCELLANEOUS
 .cache
+subprojects/*.wraplock

--- a/hyprland-share-picker/meson.build
+++ b/hyprland-share-picker/meson.build
@@ -18,6 +18,6 @@ executable('hyprland-share-picker',
   sources,
   ui_files,
   moc,
-  dependencies: qtdep,
+  dependencies: [qtdep, dependency('hyprutils')],
   install: true
 )


### PR DESCRIPTION
the meson build of hyprland-share-picker was missing the hyprutils dependency the cmake build already declares (the picker uses CProcess). add it, and ignore meson's subproject *.wraplock files.