### PR TITLE
shared: include vector header

### DIFF
--- a/src/shared/ToplevelMappingManager.hpp
+++ b/src/shared/ToplevelMappingManager.hpp
@@ -4,6 +4,7 @@
 #include "hyprland-toplevel-mapping-v1.hpp"
 #include "wlr-foreign-toplevel-management-unstable-v1.hpp"
 #include <memory>
+#include <vector>
 #include "../includes.hpp"
 
 class CToplevelMappingManager {


### PR DESCRIPTION
Adds a missing include for `std::vector` to fix the compile error `no template named 'vector' in namespace 'std'` on Gentoo Linux
<https://en.cppreference.com/cpp/container/vector>

```bash
[20/36] /usr/lib/llvm/22/bin/clang++ -DXDPH_VERSION=\"1.3.12\" -I/var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/. -I/var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/protocols -isystem /usr/include/elogind -isystem /usr/lib/libffi/include -isystem /usr/include/pipewire-0.3 -isystem /usr/include/spa-0.2 -isystem /usr/include/libdrm  -march=native -O3 -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -stdlib=libc++ -std=gnu++23 -Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith -Wno-address-of-temporary -D_REENTRANT -fno-strict-aliasing -fno-strict-overflow -MD -MT CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelManager.cpp.o -MF CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelManager.cpp.o.d -o CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelManager.cpp.o -c /var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/src/shared/ToplevelManager.cpp
[21/36] /usr/lib/llvm/22/bin/clang++ -DXDPH_VERSION=\"1.3.12\" -I/var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/. -I/var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/protocols -isystem /usr/include/elogind -isystem /usr/lib/libffi/include -isystem /usr/include/pipewire-0.3 -isystem /usr/include/spa-0.2 -isystem /usr/include/libdrm  -march=native -O3 -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -stdlib=libc++ -std=gnu++23 -Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith -Wno-address-of-temporary -D_REENTRANT -fno-strict-aliasing -fno-strict-overflow -MD -MT CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelMappingManager.cpp.o -MF CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelMappingManager.cpp.o.d -o CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelMappingManager.cpp.o -c /var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/src/shared/ToplevelMappingManager.cpp
FAILED: [code=1] CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelMappingManager.cpp.o
/usr/lib/llvm/22/bin/clang++ -DXDPH_VERSION=\"1.3.12\" -I/var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/. -I/var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/protocols -isystem /usr/include/elogind -isystem /usr/lib/libffi/include -isystem /usr/include/pipewire-0.3 -isystem /usr/include/spa-0.2 -isystem /usr/include/libdrm  -march=native -O3 -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -stdlib=libc++ -std=gnu++23 -Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith -Wno-address-of-temporary -D_REENTRANT -fno-strict-aliasing -fno-strict-overflow -MD -MT CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelMappingManager.cpp.o -MF CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelMappingManager.cpp.o.d -o CMakeFiles/xdg-desktop-portal-hyprland.dir/src/shared/ToplevelMappingManager.cpp.o -c /var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/src/shared/ToplevelMappingManager.cpp
In file included from /var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/src/shared/ToplevelMappingManager.cpp:1:
/var/tmp/portage/gui-libs/xdg-desktop-portal-hyprland-9999/work/xdg-desktop-portal-hyprland-9999/src/shared/ToplevelMappingManager.hpp:19:10: error: no template named 'vector' in namespace 'std'
   19 |     std::vector<SP<CCHyprlandToplevelWindowMappingHandleV1>>        m_vHandles;
      |     ~~~~~^
1 error generated.
ninja: build stopped: subcommand failed.
```