### PR TITLE
input-capture: destroy sessions on close

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(NOT SDBUS_FOUND)
 endif()
 
 # same for hyprland-protocols
-pkg_check_modules(HYPRLAND_PROTOS IMPORTED_TARGET hyprland-protocols)
+pkg_check_modules(HYPRLAND_PROTOS IMPORTED_TARGET hyprland-protocols>=0.8.0)
 if(HYPRLAND_PROTOS_FOUND)
   set(HYPRLAND_PROTOCOLS "${HYPRLAND_PROTOS_PREFIX}/share/hyprland-protocols")
 else()
@@ -107,6 +107,7 @@ function(protocolnew protoPath protoName external)
            ${CMAKE_SOURCE_DIR}/protocols/${protoName}.hpp
     COMMAND hyprwayland-scanner --client ${path}/${protoName}.xml
             ${CMAKE_SOURCE_DIR}/protocols/
+    DEPENDS ${path}/${protoName}.xml
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_sources(xdg-desktop-portal-hyprland PRIVATE protocols/${protoName}.cpp
                                                      protocols/${protoName}.hpp)
@@ -117,6 +118,7 @@ function(protocolWayland)
            ${CMAKE_SOURCE_DIR}/protocols/wayland.hpp
     COMMAND hyprwayland-scanner --wayland-enums --client
             ${WAYLAND_SCANNER_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
+    DEPENDS ${WAYLAND_SCANNER_DIR}/wayland.xml
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_sources(xdg-desktop-portal-hyprland PRIVATE protocols/wayland.cpp
                                                      protocols/wayland.hpp)

--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -98,7 +98,8 @@ void CPortalManager::onGlobal(uint32_t name, const char* interface, uint32_t ver
     }
     if (INTERFACE == hyprland_input_capture_manager_v1_interface.name)
         m_sPortals.inputCapture = std::make_unique<CInputCapturePortal>(makeShared<CCHyprlandInputCaptureManagerV1>(
-            (wl_proxy*)wl_registry_bind((wl_registry*)m_sWaylandConnection.registry->resource(), name, &hyprland_input_capture_manager_v1_interface, version)));
+            (wl_proxy*)wl_registry_bind((wl_registry*)m_sWaylandConnection.registry->resource(), name, &hyprland_input_capture_manager_v1_interface,
+                                        std::min(version, static_cast<uint32_t>(hyprland_input_capture_manager_v1_interface.version)))));
     else if (INTERFACE == zxdg_output_manager_v1_interface.name) {
         m_sWaylandConnection.xdgOutputManager = makeShared<CCZxdgOutputManagerV1>(
             (wl_proxy*)wl_registry_bind((wl_registry*)m_sWaylandConnection.registry->resource(), name, &zxdg_output_manager_v1_interface, std::min(version, 3u)));

--- a/src/portals/InputCapture.cpp
+++ b/src/portals/InputCapture.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <unistd.h>
 #include <unordered_map>
 #include <vector>
 #include <wayland-client-core.h>
@@ -192,6 +193,9 @@ static bool isBarrierValid(int x1, int y1, int x2, int y2) {
     return isHorizontalBarrierOnExteriorBoundary(y1, x1, x2);
 }
 
+// sending destroy to a pre-v2 compositor is an unknown opcode and kills the connection
+static constexpr int32_t INPUT_CAPTURE_DESTROY_SINCE_VERSION = 2;
+
 CInputCapturePortal::CInputCapturePortal(SP<CCHyprlandInputCaptureManagerV1> mgr) : m_sState{mgr} {
     Debug::log(LOG, "[input-capture] initializing input capture portal");
 
@@ -275,24 +279,64 @@ dbUasv CInputCapturePortal::onCreateSession(sdbus::ObjectPath requestHandle, sdb
 CInputCapturePortal::SSession::SSession(sdbus::ObjectPath requestHandle_, sdbus::ObjectPath sessionHandle_, std::string sessionId_, uint32_t capabilities_, wl_proxy* proxy) :
     requestHandle(requestHandle_), sessionHandle(sessionHandle_), sessionId(sessionId_), capabilities(capabilities_), whandle(std::make_unique<CCHyprlandInputCaptureV1>(proxy)) {
 
-    session            = createDBusSession(sessionHandle);
-    session->onDestroy = [this]() {
-        whandle->sendDisable();
-        Debug::log(LOG, "[input-capture] Session {} destroyed", sessionHandle.c_str());
-        session.release();
-        whandle.reset();
-        dead = true;
-    };
+    // ~SSession does not run on a throwing ctor, but the wrapper dtor still sends destroy
+    try {
+        session            = createDBusSession(sessionHandle);
+        session->onDestroy = [this]() {
+            // keep this alive past removeSession, so ~SSession runs after the lambda returns
+            const auto SELF = shared_from_this();
 
-    request            = createDBusRequest(requestHandle);
-    request->onDestroy = [this]() { request.release(); };
+            Debug::log(LOG, "[input-capture] Session {} destroyed", sessionHandle.c_str());
 
-    whandle->setActivated([this](CCHyprlandInputCaptureV1*, uint32_t activationId, wl_fixed_t x, wl_fixed_t y, uint32_t borderId) {
-        g_pPortalManager->m_sPortals.inputCapture->activate(sessionHandle, activationId, x, y, borderId);
-    });
-    whandle->setDeactivated([this](CCHyprlandInputCaptureV1*, uint32_t activationId) { g_pPortalManager->m_sPortals.inputCapture->deactivate(sessionHandle, activationId); });
-    whandle->setDisabled([this](CCHyprlandInputCaptureV1*) { g_pPortalManager->m_sPortals.inputCapture->disable(sessionHandle); });
-    whandle->setEisFd([this](CCHyprlandInputCaptureV1*, int32_t fd) { eisFD = fd; });
+            session.release();
+
+            destroy();
+
+            g_pPortalManager->m_sPortals.inputCapture->removeSession(sessionHandle);
+        };
+
+        request            = createDBusRequest(requestHandle);
+        request->onDestroy = [this]() { request.release(); };
+
+        whandle->setActivated([this](CCHyprlandInputCaptureV1*, uint32_t activationId, wl_fixed_t x, wl_fixed_t y, uint32_t borderId) {
+            g_pPortalManager->m_sPortals.inputCapture->activate(sessionHandle, activationId, x, y, borderId);
+        });
+        whandle->setDeactivated([this](CCHyprlandInputCaptureV1*, uint32_t activationId) { g_pPortalManager->m_sPortals.inputCapture->deactivate(sessionHandle, activationId); });
+        whandle->setDisabled([this](CCHyprlandInputCaptureV1*) { g_pPortalManager->m_sPortals.inputCapture->disable(sessionHandle); });
+        whandle->setEisFd([this](CCHyprlandInputCaptureV1*, int32_t fd) { eisFD = fd; });
+    } catch (...) {
+        destroy();
+        throw;
+    }
+}
+
+CInputCapturePortal::SSession::~SSession() {
+    destroy();
+}
+
+void CInputCapturePortal::SSession::destroy() {
+    if (dead)
+        return;
+
+    dead = true;
+
+    if (whandle && whandle->resource()) {
+        if (whandle->version() >= INPUT_CAPTURE_DESTROY_SINCE_VERSION) {
+            whandle->sendDestroy();
+            whandle.reset();
+        } else {
+            // the wrapper dtor would send destroy, so tear down by hand and leak it
+            whandle->sendDisable();
+            wl_proxy_destroy(whandle->resource());
+            whandle.release();
+        }
+    }
+
+    // the fd handed to ConnectToEIS is a dup, this one is ours
+    if (eisFD >= 0) {
+        close(eisFD);
+        eisFD = -1;
+    }
 }
 
 dbUasv CInputCapturePortal::onGetZones(sdbus::ObjectPath requestHandle, sdbus::ObjectPath sessionHandle, std::string appID, std::unordered_map<std::string, sdbus::Variant> opts) {

--- a/src/portals/InputCapture.hpp
+++ b/src/portals/InputCapture.hpp
@@ -3,6 +3,7 @@
 #include "hyprland-input-capture-v1.hpp"
 #include "../includes.hpp"
 #include "../shared/Session.hpp"
+#include <memory>
 #include <sdbus-c++/Types.h>
 
 enum ClientStatus : uint8_t {
@@ -33,8 +34,12 @@ class CInputCapturePortal {
         SP<CCHyprlandInputCaptureManagerV1> manager;
     } m_sState;
 
-    struct SSession {
+    struct SSession : std::enable_shared_from_this<SSession> {
         SSession(sdbus::ObjectPath requestHandle, sdbus::ObjectPath sessionHandle, std::string sessionId, uint32_t capabilities, wl_proxy* proxy);
+        ~SSession();
+
+        // idempotent
+        void                                   destroy();
 
         sdbus::ObjectPath                      requestHandle, sessionHandle;
         std::string                            sessionId;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This implements a destroy lifecycle on the InputCapture portal backend.

Part 2 of 3 needed for #419, leaking file descriptors from InputPortal.
Needs hyprland-protocols ≥ 0.7.1 (https://github.com/hyprwm/hyprland-protocols/pull/22, merged).

session->onDestroy sends only whandle sendDisable() and reset() which is a local teardown without wire message.  The cached eisFD isn't closed or erased from m_sessions. This sends `destroy`, closes the eisFD and erases the session.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- Breaks on older Hyprland. The generated version sends destroy unconditionally. anything before hyprwm/Hyprland#16204 would throw an "invalid method 5" error and xdph goes down. All good if Hyprland lands and releases first. If you want xdph to stay safe on older Hyprland we'd need to add a guard back
- After that error xdph also segfaults on exit, in `~CPortalManager` -> `~CCZxdgOutputV1` on the dead connection. Existing shutdown code, not touched here.
- `close(eisFD)` is safe: `sdbus::UnixFd(int)` dups via `checkedDup()`.

Built clean and installed all 3 PRs in an Arch VM as well as the latest main/master and then verified the leaking flow from #419. Also ran it under AddressSanitizer, with a real capture destroyed while active, and against an unpatched Hyprland for the break above.

#### Did you use AI in any way shape or form in the making of this PR? If so, detail how you used it. (Undisclosed AI use is a violation of the [AI Policy](https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md) and is punishable)

Yes, I had Claude do the initial diagnosis, search for existing issues or PRs in the works, do the first prototype to prove MVP, later Codex run as a reviewer and skeptic agent prior to the PR, and had an agent set up the initial VM testbed.  

I hit the bug, identified the leak, cloned the repos, wrote the first spec, made all design decisions, steered the agent through first prototype, manually validated it, manually refactored and rewrote most of the initial prototype to productionize, identified and architected version handling issues for ordering and PR splitting, addressed feedback changes and follow up coding work, and managed git and github comms myself. 

I confirm I was the active driver with full understanding of the PR before publishing.

#### Is it ready for merging, or does it need work?

Ready for review. Should merge after hyprwm/Hyprland#16204.
