### PR TITLE
screencopy: fix permanent freeze after running out of buffers

### DIFF
--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -497,10 +497,9 @@ void CScreencopyPortal::SSession::initCallbacks() {
                 // pwStreamStateChange() calls startFrameCopy() and installs a new frame
                 // callback. The reset() below then destroys it, leaving the session with
                 // no callback and nothing queued.
-                if (sharingData.copyRetries++ < MAX_RETRIES) {
+                if (sharingData.copyRetries++ < MAX_RETRIES)
                     Debug::log(LOG, "[sc] Retrying screencopy ({}/{})", sharingData.copyRetries, MAX_RETRIES);
-                    g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
-                }
+                g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
                 sharingData.frameCallback.reset();
                 return;
             }
@@ -616,10 +615,9 @@ void CScreencopyPortal::SSession::initCallbacks() {
                 // pwStreamStateChange() calls startFrameCopy() and installs a new frame
                 // callback. The reset() below then destroys it, leaving the session with
                 // no callback and nothing queued.
-                if (sharingData.copyRetries++ < MAX_RETRIES) {
+                if (sharingData.copyRetries++ < MAX_RETRIES)
                     Debug::log(LOG, "[sc] Retrying screencopy ({}/{})", sharingData.copyRetries, MAX_RETRIES);
-                    g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
-                }
+                g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
                 sharingData.windowFrameCallback.reset();
                 return;
             }

--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -492,9 +492,13 @@ void CScreencopyPortal::SSession::initCallbacks() {
             if (!PSTREAM->currentPWBuffer) {
                 Debug::log(LOG, "[screencopy/pipewire] Out of buffers");
                 sharingData.status = FRAME_NONE;
+                // Renegotiating cannot produce a buffer and breaks the session:
+                // pw_stream_update_params() re-enters STREAMING synchronously, so
+                // pwStreamStateChange() calls startFrameCopy() and installs a new frame
+                // callback. The reset() below then destroys it, leaving the session with
+                // no callback and nothing queued.
                 if (sharingData.copyRetries++ < MAX_RETRIES) {
                     Debug::log(LOG, "[sc] Retrying screencopy ({}/{})", sharingData.copyRetries, MAX_RETRIES);
-                    g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
                     g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
                 }
                 sharingData.frameCallback.reset();
@@ -607,9 +611,13 @@ void CScreencopyPortal::SSession::initCallbacks() {
             if (!PSTREAM->currentPWBuffer) {
                 Debug::log(LOG, "[screencopy/pipewire] Out of buffers");
                 sharingData.status = FRAME_NONE;
+                // Renegotiating cannot produce a buffer and breaks the session:
+                // pw_stream_update_params() re-enters STREAMING synchronously, so
+                // pwStreamStateChange() calls startFrameCopy() and installs a new frame
+                // callback. The reset() below then destroys it, leaving the session with
+                // no callback and nothing queued.
                 if (sharingData.copyRetries++ < MAX_RETRIES) {
                     Debug::log(LOG, "[sc] Retrying screencopy ({}/{})", sharingData.copyRetries, MAX_RETRIES);
-                    g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
                     g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
                 }
                 sharingData.windowFrameCallback.reset();


### PR DESCRIPTION
Fixes #423

Two independent ways a screencast session can stop receiving frames while the pipewire stream stays up.

The first commit is the actual freeze. In the out-of-buffers path, `updateStreamParam()` makes pipewire re-enter STREAMING synchronously, so `pwStreamStateChange()` runs `startFrameCopy()` and installs a new frame callback, which the `frameCallback.reset()` at the end of the same branch then destroys. The `queueNextShareFrame()` timer added in between fires into that new callback and aborts with "tried scheduling on already scheduled cb". Depending on the ordering the session either continues or is left with no callback and nothing queued. Renegotiating also reallocated the buffer pool on every retry, so one late buffer snowballed into continuous renegotiation at over 100% CPU.

The second commit covers the `MAX_RETRIES` cliff: past the limit nothing is requeued, which ends the frame loop just as permanently. Split into two commits in case you only want the first.

Tested with RustDesk 1.4.5 as the consumer (`pipewiresrc always-copy=true ! appsink max-buffers=1 drop=true`, so SHM) on Hyprland 0.55, capturing one output at 2560x1440. Sessions that reliably froze within ten seconds to two minutes now run without freezing, with the same consumer, encoder and resolution, and xdph CPU over a comparable session went from over 100% to about 3%. clang-format clean.
