### PR TITLE
screencopy: don't destroy the frame callback installed while renegotiating

### DIFF
--- a/src/portals/Screencopy.cpp
+++ b/src/portals/Screencopy.cpp
@@ -488,11 +488,11 @@ void CScreencopyPortal::SSession::initCallbacks() {
             if ((PSTREAM->pwVideoInfo.format != pwFromDrmFourcc(FMT) && PSTREAM->pwVideoInfo.format != pwStripAlpha(pwFromDrmFourcc(FMT))) ||
                 (PSTREAM->pwVideoInfo.size.width != sharingData.frameInfoDMA.w || PSTREAM->pwVideoInfo.size.height != sharingData.frameInfoDMA.h)) {
                 Debug::log(LOG, "[sc] Incompatible formats, renegotiate stream");
-                sharingData.status = FRAME_RENEG;
-                g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
-                g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
+                const auto EXPIRED = std::move(sharingData.frameCallback);
                 sharingData.status = FRAME_NONE;
-                sharingData.frameCallback.reset();
+                g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
+                if (!sharingData.frameCallback)
+                    g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
                 return;
             }
 
@@ -606,11 +606,11 @@ void CScreencopyPortal::SSession::initCallbacks() {
             if ((PSTREAM->pwVideoInfo.format != pwFromDrmFourcc(FMT) && PSTREAM->pwVideoInfo.format != pwStripAlpha(pwFromDrmFourcc(FMT))) ||
                 (PSTREAM->pwVideoInfo.size.width != sharingData.frameInfoDMA.w || PSTREAM->pwVideoInfo.size.height != sharingData.frameInfoDMA.h)) {
                 Debug::log(LOG, "[sc] Incompatible formats, renegotiate stream");
-                sharingData.status = FRAME_RENEG;
-                g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
-                g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
+                const auto EXPIRED = std::move(sharingData.windowFrameCallback);
                 sharingData.status = FRAME_NONE;
-                sharingData.windowFrameCallback.reset();
+                g_pPortalManager->m_sPortals.screencopy->m_pPipewire->updateStreamParam(PSTREAM);
+                if (!sharingData.windowFrameCallback)
+                    g_pPortalManager->m_sPortals.screencopy->queueNextShareFrame(this);
                 return;
             }
 


### PR DESCRIPTION
Same re-entrancy as #424, in the two branches that one didn't touch.

The format-mismatch branch of `buffer_done` sets `FRAME_RENEG`, calls `updateStreamParam()`, then unconditionally queues a timer and resets the frame callback. `pw_stream_update_params()` re-enters STREAMING synchronously, and with the status at `FRAME_RENEG` `pwStreamStateChange()` takes the `removeSessionFrameCallbacks()` and `startFrameCopy()` path, so a fresh callback is installed before the call returns. The `reset()` right after destroys that new callback rather than the spent one, and the timer schedules a second frame on top of it. When pipewire defers STREAMING to the next loop iteration instead, the timer's `startCopy()` finds the installed callback and aborts with "tried scheduling on already scheduled cb". Either way a frame is dropped, and the session can be left with no callback and nothing queued.

Detach the spent callback before renegotiating so the re-entrant install sees an empty slot, hold it in a local so the object currently dispatching isn't destroyed inside its own handler, and only queue if renegotiation didn't already install one. This leaves `FRAME_RENEG` unreferenced; I left the enumerator alone rather than mix a cleanup in.

Found chasing repeated portal deaths during window capture on Hyprland 0.56.1, always the same three lines in order: `Incompatible formats, renegotiate stream`, `tried scheduling on already scheduled cb (type 1)`, `wl_display#1: error 0: invalid object 22`. #418 reports the same three in the same order. The dropped frame and the freeze follow from the ordering above. The step from there to the protocol error is plausible but I haven't captured a WAYLAND_DEBUG trace pinning it, so treat that part as suspected rather than shown.

Builds and clang-format clean. The crash takes hours of real capture to hit, so I can't claim it's confirmed gone in the field yet. I also wrote a small regression test around the ordering, six checks fail against current master and pass with this, but left it out since there's no test target. Happy to open it separately if that's wanted.

Disclosure: the investigation and patch were AI-assisted, reviewed by me.
