### PR TITLE
core: destroy Wayland proxies before disconnecting the display

### DIFF
--- a/src/core/PortalManager.cpp
+++ b/src/core/PortalManager.cpp
@@ -484,11 +484,22 @@ void CPortalManager::startEventLoop() {
     m_sPortals.screencopy.reset();
     m_sPortals.screenshot.reset();
     m_sHelpers.toplevel.reset();
+    m_sHelpers.toplevelMapping.reset();
     m_sPortals.inputCapture.reset();
 
     m_pConnection.reset();
     pw_loop_destroy(m_sPipewire.loop);
+
+    m_vOutputs.clear();
+    m_sWaylandConnection.linuxDmabufFeedback.reset();
+    m_sWaylandConnection.linuxDmabuf.reset();
+    m_sWaylandConnection.xdgOutputManager.reset();
+    m_sWaylandConnection.hyprlandToplevelMgr.reset();
+    m_sWaylandConnection.shm.reset();
+    m_sWaylandConnection.registry.reset();
+
     wl_display_disconnect(m_sWaylandConnection.display);
+    m_sWaylandConnection.display = nullptr;
 
     m_sTimersThread.thread.release();
     pollThr.join(); // wait for poll to exit


### PR DESCRIPTION
## Problem

`CPortalManager::startEventLoop()` calls `wl_display_disconnect()` while output, helper, and connection proxy wrappers remain alive. Their generated destructors later destroy proxies through the freed display, causing the exit-time use-after-free in `wl_map_insert_at` reported in #340 and #351.

libwayland requires clients to destroy all proxies before disconnecting their display.

## Fix

Destroy all remaining Wayland proxy owners before disconnecting, in dependency order: child objects before managers and the registry last. Null the display pointer after disconnecting.

## Testing

- Built the portal with AddressSanitizer.
- Ran it against a disposable Wayland server advertising `wl_output`.
- Terminated the server; XDPH handled the Wayland `POLLHUP`, completed normal teardown, and exited 0 without ASan errors.

Fixes #340
Fixes #351